### PR TITLE
upd: [HF02] Use TaskEditorDialog and add toast notifications (#56)

### DIFF
--- a/run-tests.bat
+++ b/run-tests.bat
@@ -1,0 +1,6 @@
+@echo off
+echo [Efficio QA] Running Automated Feature Tests...
+pytest tests/automation/test_features.py -v
+echo.
+echo Tests Completed.
+pause

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -28,7 +28,7 @@ from PySide6.QtWidgets import (
 
 from business.task_manager import TaskManager
 from data.models import Task
-from presentation.add_task_dialog import AddTaskDialog
+from presentation.task_editor_dialog import TaskEditorDialog
 
 try:
     from config import get_default_db_path
@@ -934,7 +934,7 @@ class DashboardInterface(QWidget):
 
     def edit_specific_task(self, task_id):
         """
-        Instantiates the AddTaskDialog in 'Edit' mode and synchronizes database updates.
+        Instantiates the TaskEditorDialog in 'Edit' mode and synchronizes database updates.
 
         Args:
             task_id (int): The unique primary key of the target task to modify.
@@ -943,7 +943,7 @@ class DashboardInterface(QWidget):
         # We abstracted this so the Kanban card can call it without relying on a QListWidgetItem
         task = self.task_manager.get_task_by_id(task_id)
         if task:
-            dialog = AddTaskDialog(self, task=task)
+            dialog = TaskEditorDialog(self, task=task)
             if dialog.exec():
                 data = dialog.get_data()
                 updated_task = Task(
@@ -981,7 +981,7 @@ class DashboardInterface(QWidget):
         Opens the dialog to create a new task. Provides a success notification
         upon successfully saving the task to the database.
         """
-        dialog = AddTaskDialog(self)
+        dialog = TaskEditorDialog(self)
         if dialog.exec():
             data = dialog.get_data()
 
@@ -1087,7 +1087,7 @@ class DashboardInterface(QWidget):
             # Fetch existing task data
             task = self.task_manager.get_task_by_id(task_id)
             if task:
-                dialog = AddTaskDialog(self, task=task)
+                dialog = TaskEditorDialog(self, task=task)
                 if dialog.exec():
                     data = dialog.get_data()
 

--- a/src/presentation/task_editor_dialog.py
+++ b/src/presentation/task_editor_dialog.py
@@ -1,18 +1,19 @@
-from PySide6.QtCore import QDate, Qt
+from PySide6.QtCore import QDate, QEasingCurve, QPoint, QPropertyAnimation, Qt, QTimer
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QComboBox,
     QDateEdit,
     QDialog,
     QDialogButtonBox,
+    QGraphicsDropShadowEffect,
     QLabel,
     QLineEdit,
-    QMessageBox,
     QTextEdit,
     QVBoxLayout,
 )
 
 
-class AddTaskDialog(QDialog):
+class TaskEditorDialog(QDialog):
     def __init__(self, parent=None, task=None):
         super().__init__(parent)
         self.setWindowTitle("Edit Task" if task else "Add New Task")
@@ -20,6 +21,9 @@ class AddTaskDialog(QDialog):
         self.task = task
 
         layout = QVBoxLayout(self)
+
+        # Initialize floating toast (does not get added to layout)
+        self.toast = ToastNotification(self)
 
         # Title
         layout.addWidget(QLabel("Title (Required):"))
@@ -105,8 +109,9 @@ class AddTaskDialog(QDialog):
 
     def validate_and_accept(self):
         title = self.title_input.text().strip()
+
         if not title:
-            QMessageBox.warning(self, "Validation Error", "Title is required!")
+            self.toast.show_toast("Title is required!")
             return
 
         # --- PAST DUE DATE VALIDATION ---
@@ -127,9 +132,7 @@ class AddTaskDialog(QDialog):
 
             # If it's a NEW task, OR they changed the date to a NEW past date, block the save
             if not original_date or selected_date != original_date:
-                QMessageBox.warning(
-                    self, "Validation Error", "Due Date cannot be in the past!"
-                )
+                self.toast.show_toast("Due Date cannot be in the past!")
                 return
         # --------------------------------
 
@@ -145,3 +148,68 @@ class AddTaskDialog(QDialog):
             "status": self.task.status if self.task else "Pending",
             "color": self.color_combo.currentData(),  # Extract the hidden Hex Code
         }
+
+
+class ToastNotification(QLabel):
+    """A floating, animated notification overlay."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setStyleSheet("""
+            QLabel {
+                background-color: #2F3239;
+                color: #FFFFFF;
+                font-size: 13px;
+                font-weight: bold;
+                padding: 10px 20px;
+                border: 1px solid #4a4a4a;
+                border-radius: 8px;
+            }
+        """)
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.hide()
+
+        # Premium Shadow Hook
+        shadow = QGraphicsDropShadowEffect(self)
+        shadow.setBlurRadius(15)
+        shadow.setColor(QColor(0, 0, 0, 150))
+        shadow.setOffset(0, 4)
+        self.setGraphicsEffect(shadow)
+
+    def show_toast(self, message, duration_ms=3000):
+        self.setText(message)
+        self.adjustSize()
+
+        # Mathematical absolute positioning (Top-Center)
+        parent_rect = self.parent().rect()
+        target_x = (parent_rect.width() - self.width()) // 2
+        target_y = 20  # Hovering 20px down from the roof
+        start_y = -self.height() - 20  # Offscreen
+
+        self.setGeometry(target_x, start_y, self.width(), self.height())
+        self.show()
+        self.raise_()
+
+        # Slide Down Animation Engine
+        self.anim = QPropertyAnimation(self, b"pos")
+        self.anim.setDuration(400)
+        self.anim.setStartValue(QPoint(target_x, start_y))
+        self.anim.setEndValue(QPoint(target_x, target_y))
+        self.anim.setEasingCurve(QEasingCurve.OutBack)  # Bouncy effect!
+        self.anim.start()
+
+        # Start timer to auto-hide
+        QTimer.singleShot(duration_ms, self.hide_toast)
+
+    def hide_toast(self):
+        # Slide Up Animation
+        target_x = self.x()
+        end_y = -self.height() - 20
+
+        self.anim = QPropertyAnimation(self, b"pos")
+        self.anim.setDuration(300)
+        self.anim.setStartValue(self.pos())
+        self.anim.setEndValue(QPoint(target_x, end_y))
+        self.anim.setEasingCurve(QEasingCurve.InBack)
+        self.anim.finished.connect(self.hide)
+        self.anim.start()

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -50,19 +50,6 @@ def app_window(qtbot):
         pass
 
 
-def test_tc003_view_dashboard(app_window, qtbot):
-    """TC-003: Verify native QTreeWidget initializes Accordion Groups empty"""
-    dashboard = app_window.dashboard
-    assert dashboard.task_tree is not None
-
-    # Mathematical validation: Top level items are the 3 groups + 2 spacers = 5
-    assert dashboard.task_tree.topLevelItemCount() == 5
-
-    # Extract "To-Do" accordion. It should ONLY have 1 child (the Inline Header row).
-    todo_group = dashboard.task_tree.topLevelItem(0)
-    assert todo_group.childCount() == 1  # 0 user tasks
-
-
 def test_tc001_add_task_success(app_window, qtbot, monkeypatch):
     """TC-001: Verify creation pushes task to QTreeWidget Children"""
     dashboard = app_window.dashboard
@@ -92,34 +79,50 @@ def test_tc001_add_task_success(app_window, qtbot, monkeypatch):
     assert "Submit Project" in task_row.text(0)
 
 
-def test_tc002_add_task_empty_title_validation(app_window, qtbot, monkeypatch):
+def test_tc002_add_task_empty_title_validation(app_window, qtbot):
     """TC-002: Verify validation message for empty title blocks creation"""
     dashboard = app_window.dashboard
     todo_group = dashboard.task_tree.topLevelItem(0)
     initial_count = todo_group.childCount()
 
-    message_box_called = False
-
-    def mock_warning(*args, **kwargs):
-        nonlocal message_box_called
-        message_box_called = True
-        return QMessageBox.StandardButton.Ok
-
-    monkeypatch.setattr(QMessageBox, "warning", mock_warning)
+    # Track if our Custom Toast Overlay successfully spawns
+    toast_activated = False
 
     def interact_with_dialog():
+        nonlocal toast_activated
         top_widget = QApplication.activeModalWidget()
         if top_widget:
             top_widget.title_input.setText("")  # Blank title
             top_widget.validate_and_accept()
+
+            # Look for the internal PySide6 Toast widget instead of a MessageBox
+            if (
+                top_widget.toast.isVisible()
+                and top_widget.toast.text() == "Title is required!"
+            ):
+                toast_activated = True
+
             top_widget.reject()
 
     QTimer.singleShot(100, interact_with_dialog)
     qtbot.mouseClick(dashboard.add_btn, Qt.LeftButton)
 
-    # Verify no task was added and warning was triggered
+    # Verify no task was added and the toast successfully fired
     assert todo_group.childCount() == initial_count
-    assert message_box_called is True
+    assert toast_activated is True
+
+
+def test_tc003_view_dashboard(app_window, qtbot):
+    """TC-003: Verify native QTreeWidget initializes Accordion Groups empty"""
+    dashboard = app_window.dashboard
+    assert dashboard.task_tree is not None
+
+    # Mathematical validation: Top level items are the 3 groups + 2 spacers = 5
+    assert dashboard.task_tree.topLevelItemCount() == 5
+
+    # Extract "To-Do" accordion. It should ONLY have 1 child (the Inline Header row).
+    todo_group = dashboard.task_tree.topLevelItem(0)
+    assert todo_group.childCount() == 1  # 0 user tasks
 
 
 def test_tc004_tc005_kanban_matrix_routing(app_window, qtbot):
@@ -296,3 +299,114 @@ def test_tc009_task_color_pastel_render(app_window, qtbot):
     assert (
         fg_color.name().upper() == "#D9E0A4"
     )  # The mapped bright foreground dictionary color!
+
+
+def test_tc010_past_due_date_validation(app_window, qtbot):
+    """TC-010: Task Due Date Validation (Past Date)"""
+    from PySide6.QtCore import QDate, QTimer
+    from PySide6.QtWidgets import QApplication
+
+    dashboard = app_window.dashboard
+    todo_group = dashboard.task_tree.topLevelItem(0)
+    initial_count = todo_group.childCount()
+
+    toast_activated = False
+
+    def interact_with_dialog():
+        nonlocal toast_activated
+        top_widget = QApplication.activeModalWidget()
+        if top_widget:
+            # Set Title
+            top_widget.title_input.setText("Past Date Task")
+            # Set Due Date to yesterday
+            past_date = QDate.currentDate().addDays(-1)
+            top_widget.date_input.setDate(past_date)
+
+            top_widget.validate_and_accept()
+
+            if (
+                top_widget.toast.isVisible()
+                and top_widget.toast.text() == "Due Date cannot be in the past!"
+            ):
+                toast_activated = True
+
+            top_widget.reject()
+
+    QTimer.singleShot(100, interact_with_dialog)
+    qtbot.mouseClick(dashboard.add_btn, Qt.LeftButton)
+
+    assert todo_group.childCount() == initial_count
+    assert toast_activated is True
+
+
+def test_tc011_task_priority_selection(app_window, qtbot, monkeypatch):
+    """TC-011: Task Priority Management correctly saves"""
+    from PySide6.QtCore import Qt, QTimer
+    from PySide6.QtWidgets import QApplication, QMessageBox
+
+    # Auto-click OK on Success UI
+    monkeypatch.setattr(
+        QMessageBox,
+        "information",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Ok,
+    )
+
+    dashboard = app_window.dashboard
+    todo_group = dashboard.task_tree.topLevelItem(0)
+
+    def interact_with_dialog():
+        top_widget = QApplication.activeModalWidget()
+        if top_widget:
+            top_widget.title_input.setText("Critical Task")
+            # Set priority to "Critical"
+            index = top_widget.priority_input.findText("Critical")
+            if index >= 0:
+                top_widget.priority_input.setCurrentIndex(index)
+
+            top_widget.accept()  # Bypass validation just for saving test
+
+    QTimer.singleShot(100, interact_with_dialog)
+    qtbot.mouseClick(dashboard.add_btn, Qt.LeftButton)
+
+    # Validate the task physically rendered
+    todo_group = dashboard.task_tree.topLevelItem(
+        0
+    )  # Re-fetch because load_tasks() destroys old tree
+    assert todo_group.childCount() == 2
+
+    # Priority is in column 2, let's just fetch from DB to be scientifically accurate
+    tasks = dashboard.task_manager.get_all_tasks()
+    critical_task = None
+    for t in tasks:
+        if t.title == "Critical Task":
+            critical_task = t
+            break
+
+    assert critical_task is not None
+    assert critical_task.priority == "Critical"
+
+
+def test_tc012_toast_visibility_engine(app_window, qtbot):
+    """TC-012: Ensure physics engine uses the premium OutBack bounce."""
+    from PySide6.QtCore import QEasingCurve, Qt, QTimer
+    from PySide6.QtWidgets import QApplication
+
+    dashboard = app_window.dashboard
+
+    def interact_with_dialog():
+        top_widget = QApplication.activeModalWidget()
+        if top_widget:
+            # Verify the Toast component is loaded
+            assert hasattr(top_widget, "toast")
+
+            # Fire a fake error
+            top_widget.toast.show_toast("Fake Error", 100)
+
+            # Extract internal physics
+            curve = top_widget.toast.anim.easingCurve()
+            assert curve.type() == QEasingCurve.Type.OutBack
+
+            top_widget.reject()
+
+    QTimer.singleShot(100, interact_with_dialog)
+    qtbot.mouseClick(dashboard.add_btn, Qt.LeftButton)


### PR DESCRIPTION
- Rename AddTaskDialog to TaskEditorDialog and replace all references in the dashboard.
- Introduce a ToastNotification overlay with animated slide/bounce and drop shadow, and switch validation/error feedback to use the toast instead of QMessageBox.
- Add a run-tests.bat helper to run the feature tests. Update automation tests to assert the new toast behavior (replace QMessageBox mocks), and add/adjust tests (TC-010 through TC-012) to cover past-date validation, priority saving, and toast animation internals.