### PR TITLE
htfx: [HF01] Add past-due date validation to task dialog, CI/CD and pre-commit hooks [#47]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Pull Request Description
+Please include a summary of the change and which issue is fixed.
+
+## Naming Convention Checklist
+Before submitting, please ensure your PR Title matches the strict naming convention:
+`type: [Hierarchical-ID] description`
+
+- [ ] **Type** is one of: `ftr`, `htfx`, `epc`, `tsk`, `dcmnt`, `upd`, `chore`, `refactor`
+- [ ] **ID** is either uppercase `[ID]` like `[FT01]` or `[No-ID]`
+- [ ] The description is concise and meaningful
+
+_Example of a Valid Title_: `ftr: [FT01] built search bar`
+
+## Additional Checklist
+- [ ] My code follows the style guidelines of this project (Ruff Formatting)
+- [ ] I have performed a self-review of my own code
+- [ ] I have added/updated tests that prove my fix is effective or that my feature works

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -1,0 +1,43 @@
+name: PyInstaller Desktop CD
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers when a tag like v1.0.0 is pushed
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+
+    - name: Build Standalone Executable
+      run: |
+        pyinstaller --noconfirm --onedir --windowed --name "Efficio" "src/main.py"
+        # Optional: Zip the output directory for easy attachment
+        Compress-Archive -Path dist\Efficio\* -DestinationPath Efficio-Windows.zip
+
+    - name: Release to GitHub
+      uses: softprops/action-gh-release@v2
+      with:
+        files: Efficio-Windows.zip
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           exit 1
         fi
 
+    - name: Enforce Code Quality (Ruff)
+      run: |
+        ruff format --check .
+        ruff check .
+
     - name: Run Automated UI Tests
       env:
         QT_QPA_PLATFORM: xcb

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ data/efficio.db
 .DS_Store
 Thumbs.db
 *.pyc
+.ruff_cache

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,9 @@
+type: [ID] description
+
+# --- Efficio Commit Standard ---
+# Ensure your type is one of: ftr, htfx, epc, tsk, dcmnt, upd, chore, refactor
+# Ensure your ID is a valid tag like [FT01] or [No-ID]
+# Example:
+# ftr: [FT01] built search bar
+# chore: [No-ID] clean up unused imports
+# -------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version. Ensure it matches your local version!
     rev: v0.3.5
     hooks:
       # Run the linter.
@@ -8,3 +15,11 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: check-commit-message
+        name: Enforce Commit Naming Convention
+        entry: python scripts/check_commit_msg.py
+        language: python
+        stages: [commit-msg]

--- a/scripts/check_commit_msg.py
+++ b/scripts/check_commit_msg.py
@@ -1,0 +1,46 @@
+import sys
+import re
+
+
+def main():
+    commit_msg_filepath = sys.argv[1]
+
+    with open(commit_msg_filepath, "r") as f:
+        # Read lines, strip out comments (lines starting with #) to find the actual commit message
+        lines = f.readlines()
+
+    actual_message_lines = [line for line in lines if not line.strip().startswith("#")]
+
+    if not actual_message_lines:
+        print("Commit message is empty.")
+        sys.exit(1)
+
+    subject = actual_message_lines[0].strip()
+
+    pattern = re.compile(
+        r"^(ftr|htfx|epc|tsk|dcmnt|upd|chore|refactor):\s\[([A-Z0-9-]+|No-ID)\]\s.+",
+        re.IGNORECASE,
+    )
+
+    if not pattern.match(subject) or subject == "type: [ID] description":
+        error_msg = f"""
+Invalid commit message format: "{subject}"
+
+Required format (CONTRIBUTING.md Standards):
+type: [Hierarchical-ID] description
+
+Allowed types:
+ftr, htfx, epc, tsk, dcmnt, upd, chore, refactor
+
+Valid Examples:
+ftr: [FT01] built search bar
+chore: [No-ID] clean up files
+"""
+        print(error_msg, file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/presentation/add_task_dialog.py
+++ b/src/presentation/add_task_dialog.py
@@ -1,10 +1,15 @@
-
-from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QLabel, QLineEdit,
-    QTextEdit, QComboBox, QDialogButtonBox,
-    QDateEdit, QMessageBox
-)
 from PySide6.QtCore import QDate, Qt
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDateEdit,
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QTextEdit,
+    QVBoxLayout,
+)
 
 
 class AddTaskDialog(QDialog):
@@ -84,7 +89,7 @@ class AddTaskDialog(QDialog):
         self.color_combo.addItem("🚨 Hacker Black (Red Text)", "#000001")
         self.color_combo.addItem("📟 Matrix Black (Green Text)", "#000002")
 
-        if task and hasattr(task, 'color') and task.color:
+        if task and hasattr(task, "color") and task.color:
             index = self.color_combo.findData(task.color)
             if index >= 0:
                 self.color_combo.setCurrentIndex(index)
@@ -92,8 +97,7 @@ class AddTaskDialog(QDialog):
 
         # Buttons
         self.button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok
-            | QDialogButtonBox.StandardButton.Cancel
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
         self.button_box.accepted.connect(self.validate_and_accept)
         self.button_box.rejected.connect(self.reject)
@@ -104,6 +108,31 @@ class AddTaskDialog(QDialog):
         if not title:
             QMessageBox.warning(self, "Validation Error", "Title is required!")
             return
+
+        # --- PAST DUE DATE VALIDATION ---
+        selected_date = self.date_input.date()
+        current_date = QDate.currentDate()
+
+        # Check if the currently selected date is in the past
+        if selected_date < current_date:
+            original_date = None
+
+            # Identify if we are editing an existing task, and if so, capture its original date
+            if self.task and self.task.due_date:
+                due_str = str(self.task.due_date).strip()
+                if due_str:
+                    parsed = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                    if parsed.isValid():
+                        original_date = parsed
+
+            # If it's a NEW task, OR they changed the date to a NEW past date, block the save
+            if not original_date or selected_date != original_date:
+                QMessageBox.warning(
+                    self, "Validation Error", "Due Date cannot be in the past!"
+                )
+                return
+        # --------------------------------
+
         self.accept()
 
     def get_data(self):
@@ -114,5 +143,5 @@ class AddTaskDialog(QDialog):
             "due_date": self.date_input.date().toString(Qt.DateFormat.ISODate),
             "priority": self.priority_input.currentText(),
             "status": self.task.status if self.task else "Pending",
-            "color": self.color_combo.currentData()  # Extract the hidden Hex Code
+            "color": self.color_combo.currentData(),  # Extract the hidden Hex Code
         }

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -368,7 +368,7 @@ class DashboardInterface(QWidget):
         header_layout.addWidget(self.title_label)
         header_layout.addStretch()
 
-        # Search Bar is now flawlessly docked in the Header!
+        # Search Bar
         self.search_bar = QLineEdit()
         self.search_bar.setPlaceholderText("Search tasks...")
         self.search_bar.setFixedWidth(200)


### PR DESCRIPTION
- Add validation to prevent saving a task with a due date in the past unless editing an existing task and the due date was already in the past and unchanged.
- The change compares the selected date to QDate.currentDate(), attempts to parse the task's original due_date using QDate.fromString(Qt.DateFormat.ISODate) when present, and blocks the save with a QMessageBox if the date is newly back-dated. 
- Also includes small cleanup: reorders and normalizes imports, minor formatting tweaks

Resolves #47 