### PR TITLE
ftr: [EP02] Add Task Productivity Analytics Dashboard (#7)

### DIFF
--- a/src/business/task_manager.py
+++ b/src/business/task_manager.py
@@ -83,3 +83,78 @@ class TaskManager:
             self._data_handler.permanently_delete_task(task_id)
         except sqlite3.Error as e:
             print(f"Database Error on Permanent Delete: {e}")
+
+    def get_task_stats(self) -> dict:
+        """Aggregates task counts for the analytics dashboard.
+
+        Queries all active (non-deleted) tasks and computes counts grouped
+        by status and priority, plus the number of tasks whose due date has
+        already passed. Keeps the analytics widget completely DB-agnostic —
+        it only ever consumes this plain dictionary.
+
+        Returns:
+            dict: A flat mapping of metric names to integer counts, e.g.::
+
+                {
+                    "Pending": 3,
+                    "In Progress": 1,
+                    "Completed": 5,
+                    "Low": 2,
+                    "Medium": 3,
+                    "High": 3,
+                    "Critical": 1,
+                    "overdue": 2,
+                    "total": 9,
+                }
+        """
+        try:
+            tasks = self._data_handler.get_all_tasks()
+        except sqlite3.Error as e:
+            print(f"Database Error on Get Stats: {e}")
+            return {
+                "Pending": 0,
+                "In Progress": 0,
+                "Completed": 0,
+                "Low": 0,
+                "Medium": 0,
+                "High": 0,
+                "Critical": 0,
+                "overdue": 0,
+                "total": 0,
+            }
+
+        from datetime import date
+
+        stats: dict = {
+            "Pending": 0,
+            "In Progress": 0,
+            "Completed": 0,
+            "Low": 0,
+            "Medium": 0,
+            "High": 0,
+            "Critical": 0,
+            "overdue": 0,
+            "total": len(tasks),
+        }
+
+        today = date.today()
+
+        for task in tasks:
+            # Status aggregation
+            if task.status in stats:
+                stats[task.status] += 1
+
+            # Priority aggregation
+            if task.priority in stats:
+                stats[task.priority] += 1
+
+            # Overdue detection: non-completed tasks with a past due date
+            if task.status != "Completed" and task.due_date:
+                try:
+                    due = date.fromisoformat(str(task.due_date).strip())
+                    if due < today:
+                        stats["overdue"] += 1
+                except ValueError:
+                    pass  # Malformed date — silently skip
+
+        return stats

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -89,8 +89,8 @@ class AnalyticsWidget(QWidget):
         card = QFrame()
         card.setStyleSheet(_CARD_STYLE)
         card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(14, 14, 14, 14)
-        card_layout.setSpacing(12)
+        card_layout.setContentsMargins(12, 12, 12, 12)
+        card_layout.setSpacing(8)
 
         # Panel title
         title = QLabel("📊  Performance")
@@ -113,7 +113,7 @@ class AnalyticsWidget(QWidget):
         self._inner.setStyleSheet("background: transparent;")
         self._inner_layout = QVBoxLayout(self._inner)
         self._inner_layout.setContentsMargins(0, 0, 0, 0)
-        self._inner_layout.setSpacing(14)
+        self._inner_layout.setSpacing(10)
 
         scroll.setWidget(self._inner)
         card_layout.addWidget(scroll)
@@ -163,8 +163,9 @@ class AnalyticsWidget(QWidget):
         """Render the QPieSeries donut chart into the donut container.
 
         Creates one pie slice per status (Pending / In Progress / Completed)
-        using glassmorphism-alpha fill colours from the ACTIVE_THEME_MAP
-        palette. Slices with zero count are omitted to keep the chart clean.
+        using glassmorphism-alpha fill colours. Slice labels are hidden to
+        prevent asymmetric outside-label clipping; instead a compact inline
+        legend row with coloured dots is rendered below the chart.
 
         Args:
             stats: Aggregate dict from ``TaskManager.get_task_stats()``.
@@ -176,19 +177,17 @@ class AnalyticsWidget(QWidget):
         layout.addWidget(lbl)
 
         series = QPieSeries()
-        series.setHoleSize(0.55)
+        series.setHoleSize(0.58)
+        series.setPieSize(0.80)
 
         for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
             count = stats.get(status, 0)
-            if count == 0:
-                continue
-            slc = series.append(f"{status}  {count}", count)
+            slc = series.append("", count if count > 0 else 0)
             colour = QColor(bg_hex)
-            colour.setAlpha(180)
+            colour.setAlpha(200)
             slc.setBrush(colour)
-            slc.setLabelColor(QColor("white"))
-            slc.setLabelVisible(True)
-            slc.setLabelPosition(QPieSlice.LabelPosition.LabelOutside)
+            slc.setPen(QColor(0, 0, 0, 0))  # Remove slice border gaps
+            slc.setLabelVisible(False)  # Labels replaced by custom legend row
 
         chart = QChart()
         chart.addSeries(series)
@@ -201,9 +200,45 @@ class AnalyticsWidget(QWidget):
         view = QChartView(chart)
         view.setRenderHint(QPainter.RenderHint.Antialiasing)
         view.setStyleSheet("background: transparent; border: none;")
-        view.setFixedHeight(180)
-
+        view.setFixedHeight(150)
         layout.addWidget(view)
+
+        # Custom inline legend: ● Pending 3  ● In Progress 1  ● Done 5
+        legend_row = QHBoxLayout()
+        legend_row.setSpacing(0)
+        legend_row.setContentsMargins(0, 0, 0, 0)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            short = "Done" if status == "Completed" else status
+
+            dot = QLabel("●")
+            dot.setStyleSheet(
+                f"color: {bg_hex}; font-size: 14px; background: transparent;"
+            )
+            dot.setFixedWidth(18)
+
+            name_count = QLabel(f"{short}  {count}")
+            name_count.setStyleSheet(
+                "color: rgba(255,255,255,0.80); font-size: 10px; background: transparent;"
+            )
+
+            cell = QHBoxLayout()
+            cell.setSpacing(2)
+            cell.setContentsMargins(0, 0, 0, 0)
+            cell.addWidget(dot)
+            cell.addWidget(name_count)
+            cell.addStretch()
+
+            cell_w = QWidget()
+            cell_w.setStyleSheet("background: transparent;")
+            cell_w.setLayout(cell)
+            legend_row.addWidget(cell_w, stretch=1)
+
+        legend_w = QWidget()
+        legend_w.setStyleSheet("background: transparent;")
+        legend_w.setLayout(legend_row)
+        layout.addWidget(legend_w)
 
     def _build_priority_bars(self, stats: dict) -> None:
         """Render one styled QProgressBar row per priority level.
@@ -345,7 +380,7 @@ class AnalyticsWidget(QWidget):
         frame.setStyleSheet("QFrame { background: transparent; border: none; }")
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        layout.setSpacing(4)
         return frame
 
     @staticmethod

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -1,0 +1,366 @@
+"""
+Analytics Widget for the Efficio Dashboard.
+
+Provides a self-contained QWidget that renders three productivity metric
+sections — a completion ratio donut chart, a priority distribution bar panel,
+and an overdue KPI chip — inside a scrollable glassmorphism card.
+
+ISO 25010 Compliance:
+    - Modifiability: Each section is a private builder method; adding a new
+      metric requires adding one method and one call in refresh().
+    - Functional Suitability: Data is consumed via a plain dict from
+      TaskManager.get_task_stats(), keeping this widget DB-agnostic.
+    - Usability: Empty-state labels guide the user when no data is available.
+"""
+
+from PySide6.QtCharts import QChart, QChartView, QPieSlice, QPieSeries
+from PySide6.QtCore import QMargins, Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# ── Colour palette aligned with ACTIVE_THEME_MAP in dashboard.py ──────────────
+_STATUS_COLOURS = {
+    "Pending": ("#6579BE", "#EAB099"),  # bg_hex, label_hex
+    "In Progress": ("#92736C", "#FDF1F5"),
+    "Completed": ("#285B23", "#F2CFF1"),
+}
+
+_PRIORITY_COLOURS = {
+    "Low": "#6579BE",
+    "Medium": "#8A6729",
+    "High": "#F54800",
+    "Critical": "#FF4D4D",
+}
+
+_CARD_STYLE = """
+    QFrame {
+        background-color: rgba(0, 0, 0, 0.5);
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+"""
+
+_SECTION_TITLE_STYLE = (
+    "color: rgba(255,255,255,0.7); font-size: 11px; "
+    "font-weight: bold; letter-spacing: 1px;"
+)
+
+
+class AnalyticsWidget(QWidget):
+    """Self-contained analytics panel for the Efficio Dashboard right-sidebar.
+
+    Renders three productivity metric sections:
+
+    1. **Completion Donut** — QPieSeries breakdown of task status.
+    2. **Priority Bars** — Styled QProgressBar rows per priority level.
+    3. **Overdue Chip** — KPI badge flagging past-due tasks.
+
+    The widget owns all internal layout logic. The caller (DashboardInterface)
+    only needs to call :meth:`refresh` after any task mutation.
+
+    Example:
+        >>> widget = AnalyticsWidget()
+        >>> widget.refresh(task_manager)   # called inside load_tasks()
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialise the widget and build static layout scaffolding.
+
+        Args:
+            parent: Optional parent widget passed through to QWidget.
+        """
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        # ── Outer frame (glassmorphism card) ──────────────────────────────────
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        card = QFrame()
+        card.setStyleSheet(_CARD_STYLE)
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(14, 14, 14, 14)
+        card_layout.setSpacing(12)
+
+        # Panel title
+        title = QLabel("📊  Performance")
+        title.setStyleSheet("color: white; font-size: 14px; font-weight: bold;")
+        card_layout.addWidget(title)
+
+        # ── Scrollable inner area (enables adding more metrics freely) ────────
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+            "QScrollBar:vertical { background: rgba(0,0,0,0.2); width: 6px; "
+            "border-radius: 3px; }"
+            "QScrollBar::handle:vertical { background: rgba(255,255,255,0.3); "
+            "border-radius: 3px; }"
+        )
+
+        self._inner = QWidget()
+        self._inner.setStyleSheet("background: transparent;")
+        self._inner_layout = QVBoxLayout(self._inner)
+        self._inner_layout.setContentsMargins(0, 0, 0, 0)
+        self._inner_layout.setSpacing(14)
+
+        scroll.setWidget(self._inner)
+        card_layout.addWidget(scroll)
+        outer.addWidget(card)
+
+        # ── Build placeholder sections (populated on first refresh) ───────────
+        self._donut_container = self._make_section_container()
+        self._priority_container = self._make_section_container()
+        self._overdue_container = self._make_section_container()
+
+        self._inner_layout.addWidget(self._donut_container)
+        self._inner_layout.addWidget(self._priority_container)
+        self._inner_layout.addWidget(self._overdue_container)
+        self._inner_layout.addStretch()
+
+        # Render with zero-data empty state immediately
+        self._render_empty_state()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def refresh(self, task_manager) -> None:
+        """Re-render all metric sections using the latest database snapshot.
+
+        Calls ``task_manager.get_task_stats()`` and pipes the resulting dict
+        into each builder method. Designed to be called at the end of
+        ``DashboardInterface.load_tasks()`` with zero overhead.
+
+        Args:
+            task_manager: An instance of ``business.task_manager.TaskManager``.
+        """
+        stats = task_manager.get_task_stats()
+        self._clear_container(self._donut_container)
+        self._clear_container(self._priority_container)
+        self._clear_container(self._overdue_container)
+
+        if stats["total"] == 0:
+            self._render_empty_state()
+            return
+
+        self._build_donut_section(stats)
+        self._build_priority_bars(stats)
+        self._build_overdue_chip(stats)
+
+    # ── Private builder methods ────────────────────────────────────────────────
+
+    def _build_donut_section(self, stats: dict) -> None:
+        """Render the QPieSeries donut chart into the donut container.
+
+        Creates one pie slice per status (Pending / In Progress / Completed)
+        using glassmorphism-alpha fill colours from the ACTIVE_THEME_MAP
+        palette. Slices with zero count are omitted to keep the chart clean.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._donut_container.layout()
+
+        lbl = QLabel("COMPLETION RATIO")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        series = QPieSeries()
+        series.setHoleSize(0.55)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            if count == 0:
+                continue
+            slc = series.append(f"{status}  {count}", count)
+            colour = QColor(bg_hex)
+            colour.setAlpha(180)
+            slc.setBrush(colour)
+            slc.setLabelColor(QColor("white"))
+            slc.setLabelVisible(True)
+            slc.setLabelPosition(QPieSlice.LabelPosition.LabelOutside)
+
+        chart = QChart()
+        chart.addSeries(series)
+        chart.setBackgroundBrush(QColor(0, 0, 0, 0))
+        chart.setBackgroundRoundness(0)
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.legend().setVisible(False)
+        chart.setAnimationOptions(QChart.AnimationOption.SeriesAnimations)
+
+        view = QChartView(chart)
+        view.setRenderHint(QPainter.RenderHint.Antialiasing)
+        view.setStyleSheet("background: transparent; border: none;")
+        view.setFixedHeight(180)
+
+        layout.addWidget(view)
+
+    def _build_priority_bars(self, stats: dict) -> None:
+        """Render one styled QProgressBar row per priority level.
+
+        Bar value is expressed as a percentage of total active tasks, giving
+        an instant visual sense of workload distribution. Zero-count priorities
+        are still rendered at 0% to maintain layout consistency.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._priority_container.layout()
+
+        lbl = QLabel("PRIORITY DISTRIBUTION")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        total = max(stats["total"], 1)  # Guard zero-division
+
+        for priority, hex_colour in _PRIORITY_COLOURS.items():
+            count = stats.get(priority, 0)
+            pct = int((count / total) * 100)
+
+            row = QHBoxLayout()
+            row.setSpacing(8)
+
+            name_lbl = QLabel(priority)
+            name_lbl.setFixedWidth(55)
+            name_lbl.setStyleSheet("color: rgba(255,255,255,0.75); font-size: 11px;")
+            row.addWidget(name_lbl)
+
+            bar = QProgressBar()
+            bar.setRange(0, 100)
+            bar.setValue(pct)
+            bar.setTextVisible(False)
+            bar.setFixedHeight(8)
+            bar.setStyleSheet(f"""
+                QProgressBar {{
+                    background-color: rgba(255,255,255,0.1);
+                    border-radius: 4px;
+                    border: none;
+                }}
+                QProgressBar::chunk {{
+                    background-color: {hex_colour};
+                    border-radius: 4px;
+                }}
+            """)
+            row.addWidget(bar, stretch=1)
+
+            count_lbl = QLabel(str(count))
+            count_lbl.setFixedWidth(18)
+            count_lbl.setStyleSheet(
+                "color: rgba(255,255,255,0.55); font-size: 11px; font-weight: bold;"
+            )
+            count_lbl.setAlignment(
+                Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+            )
+            row.addWidget(count_lbl)
+
+            row_w = QWidget()
+            row_w.setStyleSheet("background: transparent;")
+            row_w.setLayout(row)
+            layout.addWidget(row_w)
+
+    def _build_overdue_chip(self, stats: dict) -> None:
+        """Render the overdue KPI pill badge into the overdue container.
+
+        Displays a red warning pill when overdue tasks exist, or a calm
+        green confirmation chip when all tasks are within schedule. Reuses
+        the same due-date detection logic established in FT04 (urgency UI).
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._overdue_container.layout()
+
+        lbl = QLabel("OVERDUE STATUS")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        overdue = stats.get("overdue", 0)
+
+        if overdue > 0:
+            text = f"⚠  {overdue} task{'s' if overdue > 1 else ''} overdue"
+            chip_style = (
+                "background-color: rgba(255, 77, 77, 0.25); "
+                "color: #FF4D4D; "
+                "border: 1px solid rgba(255, 77, 77, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+        else:
+            text = "✓  All tasks on schedule"
+            chip_style = (
+                "background-color: rgba(40, 91, 35, 0.3); "
+                "color: #A8D5A2; "
+                "border: 1px solid rgba(40, 91, 35, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+
+        chip = QLabel(text)
+        chip.setStyleSheet(chip_style)
+        chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        chip.setObjectName("overdue_chip")
+        layout.addWidget(chip)
+
+    def _render_empty_state(self) -> None:
+        """Render a friendly placeholder when the task database is empty.
+
+        Called on first initialisation and whenever refresh() receives a
+        zero-task stats dict. Clears all three containers and injects a
+        single centred label with premium typography.
+        """
+        for container in (
+            self._donut_container,
+            self._priority_container,
+            self._overdue_container,
+        ):
+            self._clear_container(container)
+
+        layout = self._donut_container.layout()
+        empty_lbl = QLabel("No tasks yet\nStart planning to see insights!")
+        empty_lbl.setStyleSheet(
+            "color: rgba(255,255,255,0.35); font-size: 13px; font-style: italic;"
+        )
+        empty_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        empty_lbl.setObjectName("empty_state_label")
+        layout.addWidget(empty_lbl)
+
+    # ── Helpers ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _make_section_container() -> QFrame:
+        """Create a transparent QFrame used as a section slot in the scroll area.
+
+        Returns:
+            QFrame: An empty container with a vertical layout and no border.
+        """
+        frame = QFrame()
+        frame.setStyleSheet("QFrame { background: transparent; border: none; }")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        return frame
+
+    @staticmethod
+    def _clear_container(container: QFrame) -> None:
+        """Remove all child widgets from a section container without memory leaks.
+
+        Uses ``deleteLater()`` to safely schedule PySide6 widget destruction
+        on the next event-loop cycle, preventing dangling C++ object references.
+
+        Args:
+            container: The QFrame whose layout children will be cleared.
+        """
+        layout = container.layout()
+        while layout.count():
+            child = layout.takeAt(0)
+            widget = child.widget()
+            if widget:
+                widget.deleteLater()

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -563,9 +563,8 @@ class DashboardInterface(QWidget):
 
         self.analytics_widget = AnalyticsWidget()
 
-        right_panel_layout.addWidget(calendar_card)
-        right_panel_layout.addWidget(self.analytics_widget)
-        right_panel_layout.addStretch()
+        right_panel_layout.addWidget(calendar_card, stretch=0)
+        right_panel_layout.addWidget(self.analytics_widget, stretch=1)
 
         dash_main_layout.addLayout(task_section_layout, 3)
         dash_main_layout.addLayout(right_panel_layout, 2)

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from business.task_manager import TaskManager
 from data.models import Task
+from presentation.analytics_widget import AnalyticsWidget
 from presentation.task_editor_dialog import TaskEditorDialog
 
 try:
@@ -560,15 +561,10 @@ class DashboardInterface(QWidget):
 
         cal_layout.addWidget(calendar)
 
-        performance_card = QFrame()
-        performance_card.setStyleSheet("""QFrame {
-        background-color: rgba(0,0,0,0.5);
-        border-radius: 20px;
-        padding: 15px;
-        }""")
+        self.analytics_widget = AnalyticsWidget()
 
         right_panel_layout.addWidget(calendar_card)
-        right_panel_layout.addWidget(performance_card)
+        right_panel_layout.addWidget(self.analytics_widget)
         right_panel_layout.addStretch()
 
         dash_main_layout.addLayout(task_section_layout, 3)
@@ -1027,6 +1023,10 @@ class DashboardInterface(QWidget):
 
                 self.task_tree.setItemWidget(row_item, 2, badge_container)
                 # -------------------------------------------------------------------------
+
+        # Refresh analytics panel so charts always mirror current task state
+        if hasattr(self, "analytics_widget"):
+            self.analytics_widget.refresh(self.task_manager)
 
     def show_kanban_context_menu(self, task, global_pos):
         """

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -601,3 +601,228 @@ def test_tc017_banner_hides_when_no_urgent_tasks(app_window, qtbot):
 
     # Banner must auto-hide
     assert not dashboard.urgent_banner_btn.isVisible()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EP02: Task Productivity Analytics Dashboard
+# TC-018 → TC-023
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tc018_analytics_widget_exists(app_window, qtbot):
+    """[EP02] TC-018: AnalyticsWidget instantiates cleanly and is wired into dashboard."""
+    from presentation.analytics_widget import AnalyticsWidget
+
+    dashboard = app_window.dashboard
+
+    # The widget must be attached to the dashboard and be a proper AnalyticsWidget
+    assert hasattr(dashboard, "analytics_widget")
+    assert isinstance(dashboard.analytics_widget, AnalyticsWidget)
+
+    # Confirm the inner scroll content area exists (structural integrity check)
+    assert hasattr(dashboard.analytics_widget, "_inner_layout")
+
+
+def test_tc019_analytics_empty_state(app_window, qtbot):
+    """[EP02] TC-019: With zero tasks the empty-state label is shown."""
+    dashboard = app_window.dashboard
+
+    # No tasks were added — ensure stats are all zero
+    stats = dashboard.task_manager.get_task_stats()
+    assert stats["total"] == 0
+    assert stats["Pending"] == 0
+    assert stats["Completed"] == 0
+    assert stats["overdue"] == 0
+
+    # Empty-state label must be present inside the donut container
+    donut_container = dashboard.analytics_widget._donut_container
+    labels = [
+        donut_container.layout().itemAt(i).widget()
+        for i in range(donut_container.layout().count())
+        if donut_container.layout().itemAt(i).widget() is not None
+    ]
+    empty_labels = [
+        w
+        for w in labels
+        if getattr(w, "objectName", lambda: "")() == "empty_state_label"
+    ]
+    assert len(empty_labels) == 1
+
+
+def test_tc020_analytics_counts_match_db(app_window, qtbot):
+    """[EP02] TC-020: Stats dict accurately reflects task records in the database."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="P1",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Medium",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="P2",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="High",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="C1",
+            description="",
+            status="Completed",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+
+    assert stats["total"] == 3
+    assert stats["Pending"] == 2
+    assert stats["Completed"] == 1
+    assert stats["In Progress"] == 0
+
+
+def test_tc021_analytics_priority_distribution(app_window, qtbot):
+    """[EP02] TC-021: Priority aggregation in stats matches tasks added per level."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Low Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Low Task 2",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="High Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="High",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+
+    assert stats["Low"] == 2
+    assert stats["High"] == 1
+    assert stats["Medium"] == 0
+    assert stats["Critical"] == 0
+
+
+def test_tc022_analytics_overdue_chip_fires(app_window, qtbot):
+    """[EP02] TC-022: A task with a past due date increments the overdue counter."""
+    from datetime import datetime
+
+    from PySide6.QtCore import QDate
+
+    dashboard = app_window.dashboard
+
+    past_date = QDate.currentDate().addDays(-3).toString("yyyy-MM-dd")
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Overdue Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date=past_date,
+            priority="High",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+    assert stats["overdue"] == 1
+
+    # Refresh the widget and verify the overdue chip renders the warning text
+    dashboard.analytics_widget.refresh(dashboard.task_manager)
+    overdue_container = dashboard.analytics_widget._overdue_container
+    widgets = [
+        overdue_container.layout().itemAt(i).widget()
+        for i in range(overdue_container.layout().count())
+        if overdue_container.layout().itemAt(i).widget() is not None
+    ]
+    chip = next(
+        (
+            w
+            for w in widgets
+            if getattr(w, "objectName", lambda: "")() == "overdue_chip"
+        ),
+        None,
+    )
+    assert chip is not None
+    assert "overdue" in chip.text()
+
+
+def test_tc023_analytics_refreshes_on_status_change(app_window, qtbot):
+    """[EP02] TC-023: Completing a task updates the analytics stats correctly."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    task_id = dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="In Progress Task",
+            description="",
+            status="In Progress",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Medium",
+            is_deleted=0,
+        )
+    )
+
+    stats_before = dashboard.task_manager.get_task_stats()
+    assert stats_before["In Progress"] == 1
+    assert stats_before["Completed"] == 0
+
+    # Simulate user completing the task (e.g. via right-click context menu)
+    dashboard.task_manager.update_task_status(task_id, "Completed")
+    dashboard.load_tasks()  # triggers analytics_widget.refresh() internally
+
+    stats_after = dashboard.task_manager.get_task_stats()
+    assert stats_after["In Progress"] == 0
+    assert stats_after["Completed"] == 1


### PR DESCRIPTION
- Add AnalyticsWidget (src/presentation/analytics_widget.py) as a self-contained
  QWidget with three metric sections: completion ratio donut chart (QPieSeries),
  priority distribution bars (styled QProgressBar rows), and overdue KPI chip.
- Add get_task_stats() to TaskManager returning a flat dict of status/priority/overdue
  counts — keeps AnalyticsWidget fully DB-agnostic.
- Wire AnalyticsWidget into DashboardInterface replacing the empty performance_card;
  refresh() is called at the end of load_tasks() for live reactive updates.
- Add TC-018 through TC-023 covering widget instantiation, empty state, count
  accuracy, priority distribution, overdue detection, and live refresh on status change.

Phase 1 of Strangler Fig refactor: analytics panel extracted as a reusable,
independently testable widget. Future metrics can be added via a single new
_build_*_section() method with zero changes to dashboard.py.