### PR TITLE
ftr: [FT11] Add due-date countdown tooltips (#62)

### DIFF
--- a/src/business/task_manager.py
+++ b/src/business/task_manager.py
@@ -83,3 +83,78 @@ class TaskManager:
             self._data_handler.permanently_delete_task(task_id)
         except sqlite3.Error as e:
             print(f"Database Error on Permanent Delete: {e}")
+
+    def get_task_stats(self) -> dict:
+        """Aggregates task counts for the analytics dashboard.
+
+        Queries all active (non-deleted) tasks and computes counts grouped
+        by status and priority, plus the number of tasks whose due date has
+        already passed. Keeps the analytics widget completely DB-agnostic —
+        it only ever consumes this plain dictionary.
+
+        Returns:
+            dict: A flat mapping of metric names to integer counts, e.g.::
+
+                {
+                    "Pending": 3,
+                    "In Progress": 1,
+                    "Completed": 5,
+                    "Low": 2,
+                    "Medium": 3,
+                    "High": 3,
+                    "Critical": 1,
+                    "overdue": 2,
+                    "total": 9,
+                }
+        """
+        try:
+            tasks = self._data_handler.get_all_tasks()
+        except sqlite3.Error as e:
+            print(f"Database Error on Get Stats: {e}")
+            return {
+                "Pending": 0,
+                "In Progress": 0,
+                "Completed": 0,
+                "Low": 0,
+                "Medium": 0,
+                "High": 0,
+                "Critical": 0,
+                "overdue": 0,
+                "total": 0,
+            }
+
+        from datetime import date
+
+        stats: dict = {
+            "Pending": 0,
+            "In Progress": 0,
+            "Completed": 0,
+            "Low": 0,
+            "Medium": 0,
+            "High": 0,
+            "Critical": 0,
+            "overdue": 0,
+            "total": len(tasks),
+        }
+
+        today = date.today()
+
+        for task in tasks:
+            # Status aggregation
+            if task.status in stats:
+                stats[task.status] += 1
+
+            # Priority aggregation
+            if task.priority in stats:
+                stats[task.priority] += 1
+
+            # Overdue detection: non-completed tasks with a past due date
+            if task.status != "Completed" and task.due_date:
+                try:
+                    due = date.fromisoformat(str(task.due_date).strip())
+                    if due < today:
+                        stats["overdue"] += 1
+                except ValueError:
+                    pass  # Malformed date — silently skip
+
+        return stats

--- a/src/business/task_manager.py
+++ b/src/business/task_manager.py
@@ -3,9 +3,21 @@ Business logic for tasks. Delegates all DB access to DataHandler.
 Keeps core logic DB-agnostic for easier testing and future upgrades.
 """
 
+import logging
 import sqlite3
 from data.models import Task
 from data.DataBaseHandler import DataHandler
+
+# ISO 25010 Security: Centralized logging prevents internal exception details from leaking
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+# Avoid duplicating handlers if module is reloaded
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    )
+    logger.addHandler(handler)
 
 
 class TaskManager:
@@ -13,84 +25,123 @@ class TaskManager:
         self.db_file = db_file
         self._data_handler = DataHandler(db_file)
 
+    def _validate_task(self, task: Task) -> bool:
+        """Validates task integrity to prevent malicious or malformed injections."""
+        if not task.title or not task.title.strip():
+            logger.warning(
+                "Security/Validation Alert: Blocked attempt to save task with empty title."
+            )
+            return False
+        if len(task.title) > 255:
+            logger.warning(
+                "Security/Validation Alert: Task title exceeds maximum allowed length."
+            )
+            return False
+
+        # Basic anti-XSS heuristic
+        malicious_patterns = ["<script>", "javascript:", "onload="]
+        title_lower = task.title.lower()
+        desc_lower = (task.description or "").lower()
+        if any(p in title_lower or p in desc_lower for p in malicious_patterns):
+            logger.warning(
+                "Security/Validation Alert: Blocked potential script injection attempt."
+            )
+            return False
+
+        return True
+
     def close(self) -> None:
         """Close DB connection. Call on shutdown to avoid file locks."""
         self._data_handler.close()
 
     def add_task(self, task: Task) -> int:
-        """Saves a new task to the database safely."""
+        """Saves a new task to the database safely after validation."""
+        if not self._validate_task(task):
+            return -1
         try:
             return self._data_handler.add_task(task)
-        except sqlite3.Error as e:
-            print(f"Database Error on Add: {e}")
+        except sqlite3.Error:
+            logger.error(
+                "Database Integrity Error on Add (details masked for security)"
+            )
             return -1
 
     def get_all_tasks(self, search_query: str = "") -> list:
         """Fetches all active tasks, optionally applying a keyword search."""
         try:
             return self._data_handler.get_all_tasks(search_query)
-        except sqlite3.Error as e:
-            print(f"Database Error: {e}")
+        except sqlite3.Error:
+            logger.error(
+                "Database Query Error on Get All (details masked for security)"
+            )
             return []
 
     def get_task_by_id(self, task_id: int):
         """Fetches a specific task by ID securely."""
         try:
             return self._data_handler.get_task_by_id(task_id)
-        except sqlite3.Error as e:
-            print(f"Database Error on Get ID: {e}")
+        except sqlite3.Error:
+            logger.error(
+                f"Database Query Error on Get ID for Task {task_id} (details masked)"
+            )
             return None
 
     def delete_task(self, task_id: int) -> None:
         """Deletes a task safely."""
         try:
             self._data_handler.delete_task(task_id)
-        except sqlite3.Error as e:
-            print(f"Database Error on Delete: {e}")
+        except sqlite3.Error:
+            logger.error(f"Database Integrity Error on Delete for Task {task_id}")
 
     def update_task_status(self, task_id: int, status: str) -> None:
         """Updates just the string status of a specific task."""
         try:
             self._data_handler.update_task_status(task_id, status)
-        except sqlite3.Error as e:
-            print(f"Database Error on Update Status: {e}")
+        except sqlite3.Error:
+            logger.error(
+                f"Database Integrity Error on Update Status for Task {task_id}"
+            )
 
     def update_task(self, task: Task) -> None:
-        """Updates an entire task object securely."""
+        """Updates an entire task object securely after validation."""
+        if not self._validate_task(task):
+            return
         try:
             self._data_handler.update_task(task)
-        except sqlite3.Error as e:
-            print(f"Database Error on Update: {e}")
+        except sqlite3.Error:
+            logger.error(f"Database Integrity Error on Update for Task {task.id}")
 
     def get_deleted_tasks(self, search_query: str = "") -> list:
         """Fetches all tasks from the Trash securely, optionally applying a keyword search."""
         try:
             return self._data_handler.get_deleted_tasks(search_query)
-        except sqlite3.Error as e:
-            print(f"Database Error on Get Deleted: {e}")
+        except sqlite3.Error:
+            logger.error(
+                "Database Query Error on Get Deleted (details masked for security)"
+            )
             return []
 
     def restore_task(self, task_id: int) -> None:
         """Restores a task from the Trash securely."""
         try:
             self._data_handler.restore_task(task_id)
-        except sqlite3.Error as e:
-            print(f"Database Error on Restore: {e}")
+        except sqlite3.Error:
+            logger.error(f"Database Integrity Error on Restore for Task {task_id}")
 
     def permanently_delete_task(self, task_id: int) -> None:
         """Permanently obliterates a task from storage."""
         try:
             self._data_handler.permanently_delete_task(task_id)
-        except sqlite3.Error as e:
-            print(f"Database Error on Permanent Delete: {e}")
+        except sqlite3.Error:
+            logger.error(
+                f"Database Integrity Error on Permanent Delete for Task {task_id}"
+            )
 
-    def get_task_stats(self) -> dict:
+    def get_task_stats(self, tasks_list: list = None) -> dict:
         """Aggregates task counts for the analytics dashboard.
 
-        Queries all active (non-deleted) tasks and computes counts grouped
-        by status and priority, plus the number of tasks whose due date has
-        already passed. Keeps the analytics widget completely DB-agnostic —
-        it only ever consumes this plain dictionary.
+        If a list of tasks is provided, computes stats for that exact list
+        (respecting UI filters). Otherwise, queries all active tasks.
 
         Returns:
             dict: A flat mapping of metric names to integer counts, e.g.::
@@ -107,21 +158,26 @@ class TaskManager:
                     "total": 9,
                 }
         """
-        try:
-            tasks = self._data_handler.get_all_tasks()
-        except sqlite3.Error as e:
-            print(f"Database Error on Get Stats: {e}")
-            return {
-                "Pending": 0,
-                "In Progress": 0,
-                "Completed": 0,
-                "Low": 0,
-                "Medium": 0,
-                "High": 0,
-                "Critical": 0,
-                "overdue": 0,
-                "total": 0,
-            }
+        if tasks_list is None:
+            try:
+                tasks = self._data_handler.get_all_tasks()
+            except sqlite3.Error:
+                logger.error(
+                    "Database Query Error on Get Stats (details masked for security)"
+                )
+                return {
+                    "Pending": 0,
+                    "In Progress": 0,
+                    "Completed": 0,
+                    "Low": 0,
+                    "Medium": 0,
+                    "High": 0,
+                    "Critical": 0,
+                    "overdue": 0,
+                    "total": 0,
+                }
+        else:
+            tasks = tasks_list
 
         from datetime import date
 

--- a/src/business/task_manager.py
+++ b/src/business/task_manager.py
@@ -5,8 +5,9 @@ Keeps core logic DB-agnostic for easier testing and future upgrades.
 
 import logging
 import sqlite3
-from data.models import Task
+
 from data.DataBaseHandler import DataHandler
+from data.models import Task
 
 # ISO 25010 Security: Centralized logging prevents internal exception details from leaking
 logger = logging.getLogger(__name__)
@@ -179,7 +180,7 @@ class TaskManager:
         else:
             tasks = tasks_list
 
-        from datetime import date
+        from datetime import datetime
 
         stats: dict = {
             "Pending": 0,
@@ -193,7 +194,7 @@ class TaskManager:
             "total": len(tasks),
         }
 
-        today = date.today()
+        now = datetime.now()
 
         for task in tasks:
             # Status aggregation
@@ -204,13 +205,22 @@ class TaskManager:
             if task.priority in stats:
                 stats[task.priority] += 1
 
-            # Overdue detection: non-completed tasks with a past due date
+            # Overdue detection: non-completed tasks with a past due datetime
             if task.status != "Completed" and task.due_date:
+                due_str = str(task.due_date).strip()
                 try:
-                    due = date.fromisoformat(str(task.due_date).strip())
-                    if due < today:
+                    due = datetime.fromisoformat(due_str)
+                    if due < now:
                         stats["overdue"] += 1
                 except ValueError:
-                    pass  # Malformed date — silently skip
+                    try:
+                        # Legacy task with no time, just date
+                        # We assume end of day for deadline
+                        legacy_date = datetime.strptime(due_str, "%Y-%m-%d")
+                        legacy_due = legacy_date.replace(hour=23, minute=59, second=59)
+                        if legacy_due < now:
+                            stats["overdue"] += 1
+                    except ValueError:
+                        pass  # Malformed string - silently skip
 
         return stats

--- a/src/config.py
+++ b/src/config.py
@@ -1,20 +1,34 @@
-"""
-Central configuration for the application.
-Single source of truth for paths and settings.
-"""
-
 import os
+import platform
+from pathlib import Path
 
 
 def get_default_db_path():
-    # This automatically finds the absolute path of the 'src' folder where config.py lives
-    src_dir = os.path.dirname(os.path.abspath(__file__))
+    """
+    ISO 25010 Security (Confidentiality) Update:
+    Instead of storing the database in the open `src/data` folder where anyone
+    with access to the project can read it, we now store it in the OS's secure
+    user-specific AppData / Home directory.
 
-    # Path to the data folder
-    data_dir = os.path.join(src_dir, "data")
+    This leverages native OS file permissions (sandboxing), ensuring that
+    only the currently logged-in user can access the database file.
+    """
+    # 1. Determine the secure user-specific data directory based on the OS
+    if platform.system() == "Windows":
+        # Usually C:\Users\Username\AppData\Roaming
+        base_dir = Path(os.environ.get("APPDATA", Path.home()))
+    elif platform.system() == "Darwin":
+        # macOS: ~/Library/Application Support
+        base_dir = Path.home() / "Library" / "Application Support"
+    else:
+        # Linux/Unix: ~/.local/share
+        base_dir = Path.home() / ".local" / "share"
 
-    # Ensure the folder exists before SQLite tries to read/write!
-    if not os.path.exists(data_dir):
-        os.makedirs(data_dir)
+    # 2. Append our specific application folder
+    app_dir = base_dir / "Efficio" / "data"
 
-    return os.path.join(data_dir, "efficio.db")
+    # 3. Create the directory securely if it doesn't exist
+    app_dir.mkdir(parents=True, exist_ok=True)
+
+    # 4. Return the absolute path to the secure database
+    return str(app_dir / "efficio.db")

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,8 @@
-import sys
 import os
+import sys
+
 from PySide6.QtWidgets import QApplication, QMainWindow
+
 from config import get_default_db_path
 from data.DataBaseHandler import init_db
 from presentation.dashboard import DashboardInterface
@@ -8,6 +10,54 @@ from presentation.dashboard import DashboardInterface
 # Setup Path
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
+
+
+SCROLLBAR_STYLE = """
+    QScrollBar:vertical {
+        background: rgba(255, 255, 255, 0.03);
+        width: 8px;
+        border-radius: 4px;
+        margin: 0px;
+    }
+    QScrollBar::handle:vertical {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 4px;
+        min-height: 30px;
+    }
+    QScrollBar::handle:vertical:hover {
+        background: rgba(255, 255, 255, 0.35);
+    }
+    QScrollBar::add-line:vertical,
+    QScrollBar::sub-line:vertical {
+        height: 0px;  /* removes the arrow buttons */
+    }
+    QScrollBar::add-page:vertical,
+    QScrollBar::sub-page:vertical {
+        background: none;
+    }
+    QScrollBar:horizontal {
+        background: rgba(255, 255, 255, 0.03);
+        height: 8px;
+        border-radius: 4px;
+        margin: 0px;
+    }
+    QScrollBar::handle:horizontal {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 4px;
+        min-width: 30px;
+    }
+    QScrollBar::handle:horizontal:hover {
+        background: rgba(255, 255, 255, 0.35);
+    }
+    QScrollBar::add-line:horizontal,
+    QScrollBar::sub-line:horizontal {
+        width: 0px;
+    }
+    QScrollBar::add-page:horizontal,
+    QScrollBar::sub-page:horizontal {
+        background: none;
+    }
+"""
 
 
 class MainWindow(QMainWindow):
@@ -32,6 +82,7 @@ if __name__ == "__main__":
 
     # Run App
     app = QApplication(sys.argv)
+    app.setStyleSheet(SCROLLBAR_STYLE)
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -13,7 +13,7 @@ ISO 25010 Compliance:
     - Usability: Empty-state labels guide the user when no data is available.
 """
 
-from PySide6.QtCharts import QChart, QChartView, QPieSlice, QPieSeries
+from PySide6.QtCharts import QChart, QChartView, QPieSeries
 from PySide6.QtCore import QMargins, Qt
 from PySide6.QtGui import QColor, QPainter
 from PySide6.QtWidgets import (
@@ -134,7 +134,7 @@ class AnalyticsWidget(QWidget):
 
     # ── Public API ─────────────────────────────────────────────────────────────
 
-    def refresh(self, task_manager) -> None:
+    def refresh(self, task_manager, tasks_list: list = None) -> None:
         """Re-render all metric sections using the latest database snapshot.
 
         Calls ``task_manager.get_task_stats()`` and pipes the resulting dict
@@ -143,8 +143,9 @@ class AnalyticsWidget(QWidget):
 
         Args:
             task_manager: An instance of ``business.task_manager.TaskManager``.
+            tasks_list: Optional explicitly filtered list of tasks to compute stats for.
         """
-        stats = task_manager.get_task_stats()
+        stats = task_manager.get_task_stats(tasks_list)
         self._clear_container(self._donut_container)
         self._clear_container(self._priority_container)
         self._clear_container(self._overdue_container)

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -89,8 +89,8 @@ class AnalyticsWidget(QWidget):
         card = QFrame()
         card.setStyleSheet(_CARD_STYLE)
         card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(14, 14, 14, 14)
-        card_layout.setSpacing(12)
+        card_layout.setContentsMargins(12, 12, 12, 12)
+        card_layout.setSpacing(8)
 
         # Panel title
         title = QLabel("📊  Performance")
@@ -113,7 +113,7 @@ class AnalyticsWidget(QWidget):
         self._inner.setStyleSheet("background: transparent;")
         self._inner_layout = QVBoxLayout(self._inner)
         self._inner_layout.setContentsMargins(0, 0, 0, 0)
-        self._inner_layout.setSpacing(14)
+        self._inner_layout.setSpacing(10)
 
         scroll.setWidget(self._inner)
         card_layout.addWidget(scroll)
@@ -163,8 +163,9 @@ class AnalyticsWidget(QWidget):
         """Render the QPieSeries donut chart into the donut container.
 
         Creates one pie slice per status (Pending / In Progress / Completed)
-        using glassmorphism-alpha fill colours from the ACTIVE_THEME_MAP
-        palette. Slices with zero count are omitted to keep the chart clean.
+        using glassmorphism-alpha fill colours. Slice labels are hidden to
+        prevent asymmetric outside-label clipping; instead a compact inline
+        legend row with coloured dots is rendered below the chart.
 
         Args:
             stats: Aggregate dict from ``TaskManager.get_task_stats()``.
@@ -176,19 +177,17 @@ class AnalyticsWidget(QWidget):
         layout.addWidget(lbl)
 
         series = QPieSeries()
-        series.setHoleSize(0.55)
+        series.setHoleSize(0.58)
+        series.setPieSize(0.80)
 
         for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
             count = stats.get(status, 0)
-            if count == 0:
-                continue
-            slc = series.append(f"{status}  {count}", count)
+            slc = series.append("", count if count > 0 else 0)
             colour = QColor(bg_hex)
-            colour.setAlpha(180)
+            colour.setAlpha(200)
             slc.setBrush(colour)
-            slc.setLabelColor(QColor("white"))
-            slc.setLabelVisible(True)
-            slc.setLabelPosition(QPieSlice.LabelPosition.LabelOutside)
+            slc.setPen(QColor(0, 0, 0, 0))  # Remove slice border gaps
+            slc.setLabelVisible(False)  # Labels replaced by custom legend row
 
         chart = QChart()
         chart.addSeries(series)
@@ -201,9 +200,45 @@ class AnalyticsWidget(QWidget):
         view = QChartView(chart)
         view.setRenderHint(QPainter.RenderHint.Antialiasing)
         view.setStyleSheet("background: transparent; border: none;")
-        view.setFixedHeight(180)
-
+        view.setFixedHeight(150)
         layout.addWidget(view)
+
+        # Custom inline legend: ● Pending 3  ● In Progress 1  ● Done 5
+        legend_row = QHBoxLayout()
+        legend_row.setSpacing(0)
+        legend_row.setContentsMargins(0, 0, 0, 0)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            short = "Done" if status == "Completed" else status
+
+            dot = QLabel("●")
+            dot.setStyleSheet(
+                f"color: {bg_hex}; font-size: 14px; background: transparent;"
+            )
+            dot.setFixedWidth(18)
+
+            name_count = QLabel(f"{short}  {count}")
+            name_count.setStyleSheet(
+                "color: rgba(255,255,255,0.80); font-size: 10px; background: transparent;"
+            )
+
+            cell = QHBoxLayout()
+            cell.setSpacing(2)
+            cell.setContentsMargins(0, 0, 0, 0)
+            cell.addWidget(dot)
+            cell.addWidget(name_count)
+            cell.addStretch()
+
+            cell_w = QWidget()
+            cell_w.setStyleSheet("background: transparent;")
+            cell_w.setLayout(cell)
+            legend_row.addWidget(cell_w, stretch=1)
+
+        legend_w = QWidget()
+        legend_w.setStyleSheet("background: transparent;")
+        legend_w.setLayout(legend_row)
+        layout.addWidget(legend_w)
 
     def _build_priority_bars(self, stats: dict) -> None:
         """Render one styled QProgressBar row per priority level.
@@ -345,7 +380,7 @@ class AnalyticsWidget(QWidget):
         frame.setStyleSheet("QFrame { background: transparent; border: none; }")
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        layout.setSpacing(4)
         return frame
 
     @staticmethod

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -1,0 +1,366 @@
+"""
+Analytics Widget for the Efficio Dashboard.
+
+Provides a self-contained QWidget that renders three productivity metric
+sections — a completion ratio donut chart, a priority distribution bar panel,
+and an overdue KPI chip — inside a scrollable glassmorphism card.
+
+ISO 25010 Compliance:
+    - Modifiability: Each section is a private builder method; adding a new
+      metric requires adding one method and one call in refresh().
+    - Functional Suitability: Data is consumed via a plain dict from
+      TaskManager.get_task_stats(), keeping this widget DB-agnostic.
+    - Usability: Empty-state labels guide the user when no data is available.
+"""
+
+from PySide6.QtCharts import QChart, QChartView, QPieSlice, QPieSeries
+from PySide6.QtCore import QMargins, Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# ── Colour palette aligned with ACTIVE_THEME_MAP in dashboard.py ──────────────
+_STATUS_COLOURS = {
+    "Pending": ("#6579BE", "#EAB099"),  # bg_hex, label_hex
+    "In Progress": ("#92736C", "#FDF1F5"),
+    "Completed": ("#285B23", "#F2CFF1"),
+}
+
+_PRIORITY_COLOURS = {
+    "Low": "#6579BE",
+    "Medium": "#8A6729",
+    "High": "#F54800",
+    "Critical": "#FF4D4D",
+}
+
+_CARD_STYLE = """
+    QFrame {
+        background-color: rgba(0, 0, 0, 0.5);
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+"""
+
+_SECTION_TITLE_STYLE = (
+    "color: rgba(255,255,255,0.7); font-size: 11px; "
+    "font-weight: bold; letter-spacing: 1px;"
+)
+
+
+class AnalyticsWidget(QWidget):
+    """Self-contained analytics panel for the Efficio Dashboard right-sidebar.
+
+    Renders three productivity metric sections:
+
+    1. **Completion Donut** — QPieSeries breakdown of task status.
+    2. **Priority Bars** — Styled QProgressBar rows per priority level.
+    3. **Overdue Chip** — KPI badge flagging past-due tasks.
+
+    The widget owns all internal layout logic. The caller (DashboardInterface)
+    only needs to call :meth:`refresh` after any task mutation.
+
+    Example:
+        >>> widget = AnalyticsWidget()
+        >>> widget.refresh(task_manager)   # called inside load_tasks()
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialise the widget and build static layout scaffolding.
+
+        Args:
+            parent: Optional parent widget passed through to QWidget.
+        """
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        # ── Outer frame (glassmorphism card) ──────────────────────────────────
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        card = QFrame()
+        card.setStyleSheet(_CARD_STYLE)
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(14, 14, 14, 14)
+        card_layout.setSpacing(12)
+
+        # Panel title
+        title = QLabel("📊  Performance")
+        title.setStyleSheet("color: white; font-size: 14px; font-weight: bold;")
+        card_layout.addWidget(title)
+
+        # ── Scrollable inner area (enables adding more metrics freely) ────────
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+            "QScrollBar:vertical { background: rgba(0,0,0,0.2); width: 6px; "
+            "border-radius: 3px; }"
+            "QScrollBar::handle:vertical { background: rgba(255,255,255,0.3); "
+            "border-radius: 3px; }"
+        )
+
+        self._inner = QWidget()
+        self._inner.setStyleSheet("background: transparent;")
+        self._inner_layout = QVBoxLayout(self._inner)
+        self._inner_layout.setContentsMargins(0, 0, 0, 0)
+        self._inner_layout.setSpacing(14)
+
+        scroll.setWidget(self._inner)
+        card_layout.addWidget(scroll)
+        outer.addWidget(card)
+
+        # ── Build placeholder sections (populated on first refresh) ───────────
+        self._donut_container = self._make_section_container()
+        self._priority_container = self._make_section_container()
+        self._overdue_container = self._make_section_container()
+
+        self._inner_layout.addWidget(self._donut_container)
+        self._inner_layout.addWidget(self._priority_container)
+        self._inner_layout.addWidget(self._overdue_container)
+        self._inner_layout.addStretch()
+
+        # Render with zero-data empty state immediately
+        self._render_empty_state()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def refresh(self, task_manager) -> None:
+        """Re-render all metric sections using the latest database snapshot.
+
+        Calls ``task_manager.get_task_stats()`` and pipes the resulting dict
+        into each builder method. Designed to be called at the end of
+        ``DashboardInterface.load_tasks()`` with zero overhead.
+
+        Args:
+            task_manager: An instance of ``business.task_manager.TaskManager``.
+        """
+        stats = task_manager.get_task_stats()
+        self._clear_container(self._donut_container)
+        self._clear_container(self._priority_container)
+        self._clear_container(self._overdue_container)
+
+        if stats["total"] == 0:
+            self._render_empty_state()
+            return
+
+        self._build_donut_section(stats)
+        self._build_priority_bars(stats)
+        self._build_overdue_chip(stats)
+
+    # ── Private builder methods ────────────────────────────────────────────────
+
+    def _build_donut_section(self, stats: dict) -> None:
+        """Render the QPieSeries donut chart into the donut container.
+
+        Creates one pie slice per status (Pending / In Progress / Completed)
+        using glassmorphism-alpha fill colours from the ACTIVE_THEME_MAP
+        palette. Slices with zero count are omitted to keep the chart clean.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._donut_container.layout()
+
+        lbl = QLabel("COMPLETION RATIO")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        series = QPieSeries()
+        series.setHoleSize(0.55)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            if count == 0:
+                continue
+            slc = series.append(f"{status}  {count}", count)
+            colour = QColor(bg_hex)
+            colour.setAlpha(180)
+            slc.setBrush(colour)
+            slc.setLabelColor(QColor("white"))
+            slc.setLabelVisible(True)
+            slc.setLabelPosition(QPieSlice.LabelPosition.LabelOutside)
+
+        chart = QChart()
+        chart.addSeries(series)
+        chart.setBackgroundBrush(QColor(0, 0, 0, 0))
+        chart.setBackgroundRoundness(0)
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.legend().setVisible(False)
+        chart.setAnimationOptions(QChart.AnimationOption.SeriesAnimations)
+
+        view = QChartView(chart)
+        view.setRenderHint(QPainter.RenderHint.Antialiasing)
+        view.setStyleSheet("background: transparent; border: none;")
+        view.setFixedHeight(180)
+
+        layout.addWidget(view)
+
+    def _build_priority_bars(self, stats: dict) -> None:
+        """Render one styled QProgressBar row per priority level.
+
+        Bar value is expressed as a percentage of total active tasks, giving
+        an instant visual sense of workload distribution. Zero-count priorities
+        are still rendered at 0% to maintain layout consistency.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._priority_container.layout()
+
+        lbl = QLabel("PRIORITY DISTRIBUTION")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        total = max(stats["total"], 1)  # Guard zero-division
+
+        for priority, hex_colour in _PRIORITY_COLOURS.items():
+            count = stats.get(priority, 0)
+            pct = int((count / total) * 100)
+
+            row = QHBoxLayout()
+            row.setSpacing(8)
+
+            name_lbl = QLabel(priority)
+            name_lbl.setFixedWidth(55)
+            name_lbl.setStyleSheet("color: rgba(255,255,255,0.75); font-size: 11px;")
+            row.addWidget(name_lbl)
+
+            bar = QProgressBar()
+            bar.setRange(0, 100)
+            bar.setValue(pct)
+            bar.setTextVisible(False)
+            bar.setFixedHeight(8)
+            bar.setStyleSheet(f"""
+                QProgressBar {{
+                    background-color: rgba(255,255,255,0.1);
+                    border-radius: 4px;
+                    border: none;
+                }}
+                QProgressBar::chunk {{
+                    background-color: {hex_colour};
+                    border-radius: 4px;
+                }}
+            """)
+            row.addWidget(bar, stretch=1)
+
+            count_lbl = QLabel(str(count))
+            count_lbl.setFixedWidth(18)
+            count_lbl.setStyleSheet(
+                "color: rgba(255,255,255,0.55); font-size: 11px; font-weight: bold;"
+            )
+            count_lbl.setAlignment(
+                Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+            )
+            row.addWidget(count_lbl)
+
+            row_w = QWidget()
+            row_w.setStyleSheet("background: transparent;")
+            row_w.setLayout(row)
+            layout.addWidget(row_w)
+
+    def _build_overdue_chip(self, stats: dict) -> None:
+        """Render the overdue KPI pill badge into the overdue container.
+
+        Displays a red warning pill when overdue tasks exist, or a calm
+        green confirmation chip when all tasks are within schedule. Reuses
+        the same due-date detection logic established in FT04 (urgency UI).
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._overdue_container.layout()
+
+        lbl = QLabel("OVERDUE STATUS")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        overdue = stats.get("overdue", 0)
+
+        if overdue > 0:
+            text = f"⚠  {overdue} task{'s' if overdue > 1 else ''} overdue"
+            chip_style = (
+                "background-color: rgba(255, 77, 77, 0.25); "
+                "color: #FF4D4D; "
+                "border: 1px solid rgba(255, 77, 77, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+        else:
+            text = "✓  All tasks on schedule"
+            chip_style = (
+                "background-color: rgba(40, 91, 35, 0.3); "
+                "color: #A8D5A2; "
+                "border: 1px solid rgba(40, 91, 35, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+
+        chip = QLabel(text)
+        chip.setStyleSheet(chip_style)
+        chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        chip.setObjectName("overdue_chip")
+        layout.addWidget(chip)
+
+    def _render_empty_state(self) -> None:
+        """Render a friendly placeholder when the task database is empty.
+
+        Called on first initialisation and whenever refresh() receives a
+        zero-task stats dict. Clears all three containers and injects a
+        single centred label with premium typography.
+        """
+        for container in (
+            self._donut_container,
+            self._priority_container,
+            self._overdue_container,
+        ):
+            self._clear_container(container)
+
+        layout = self._donut_container.layout()
+        empty_lbl = QLabel("No tasks yet\nStart planning to see insights!")
+        empty_lbl.setStyleSheet(
+            "color: rgba(255,255,255,0.35); font-size: 13px; font-style: italic;"
+        )
+        empty_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        empty_lbl.setObjectName("empty_state_label")
+        layout.addWidget(empty_lbl)
+
+    # ── Helpers ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _make_section_container() -> QFrame:
+        """Create a transparent QFrame used as a section slot in the scroll area.
+
+        Returns:
+            QFrame: An empty container with a vertical layout and no border.
+        """
+        frame = QFrame()
+        frame.setStyleSheet("QFrame { background: transparent; border: none; }")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        return frame
+
+    @staticmethod
+    def _clear_container(container: QFrame) -> None:
+        """Remove all child widgets from a section container without memory leaks.
+
+        Uses ``deleteLater()`` to safely schedule PySide6 widget destruction
+        on the next event-loop cycle, preventing dangling C++ object references.
+
+        Args:
+            container: The QFrame whose layout children will be cleared.
+        """
+        layout = container.layout()
+        while layout.count():
+            child = layout.takeAt(0)
+            widget = child.widget()
+            if widget:
+                widget.deleteLater()

--- a/src/presentation/analytics_widget.py
+++ b/src/presentation/analytics_widget.py
@@ -1,0 +1,401 @@
+"""
+Analytics Widget for the Efficio Dashboard.
+
+Provides a self-contained QWidget that renders three productivity metric
+sections — a completion ratio donut chart, a priority distribution bar panel,
+and an overdue KPI chip — inside a scrollable glassmorphism card.
+
+ISO 25010 Compliance:
+    - Modifiability: Each section is a private builder method; adding a new
+      metric requires adding one method and one call in refresh().
+    - Functional Suitability: Data is consumed via a plain dict from
+      TaskManager.get_task_stats(), keeping this widget DB-agnostic.
+    - Usability: Empty-state labels guide the user when no data is available.
+"""
+
+from PySide6.QtCharts import QChart, QChartView, QPieSlice, QPieSeries
+from PySide6.QtCore import QMargins, Qt
+from PySide6.QtGui import QColor, QPainter
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+# ── Colour palette aligned with ACTIVE_THEME_MAP in dashboard.py ──────────────
+_STATUS_COLOURS = {
+    "Pending": ("#6579BE", "#EAB099"),  # bg_hex, label_hex
+    "In Progress": ("#92736C", "#FDF1F5"),
+    "Completed": ("#285B23", "#F2CFF1"),
+}
+
+_PRIORITY_COLOURS = {
+    "Low": "#6579BE",
+    "Medium": "#8A6729",
+    "High": "#F54800",
+    "Critical": "#FF4D4D",
+}
+
+_CARD_STYLE = """
+    QFrame {
+        background-color: rgba(0, 0, 0, 0.5);
+        border-radius: 16px;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+"""
+
+_SECTION_TITLE_STYLE = (
+    "color: rgba(255,255,255,0.7); font-size: 11px; "
+    "font-weight: bold; letter-spacing: 1px;"
+)
+
+
+class AnalyticsWidget(QWidget):
+    """Self-contained analytics panel for the Efficio Dashboard right-sidebar.
+
+    Renders three productivity metric sections:
+
+    1. **Completion Donut** — QPieSeries breakdown of task status.
+    2. **Priority Bars** — Styled QProgressBar rows per priority level.
+    3. **Overdue Chip** — KPI badge flagging past-due tasks.
+
+    The widget owns all internal layout logic. The caller (DashboardInterface)
+    only needs to call :meth:`refresh` after any task mutation.
+
+    Example:
+        >>> widget = AnalyticsWidget()
+        >>> widget.refresh(task_manager)   # called inside load_tasks()
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        """Initialise the widget and build static layout scaffolding.
+
+        Args:
+            parent: Optional parent widget passed through to QWidget.
+        """
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        # ── Outer frame (glassmorphism card) ──────────────────────────────────
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        card = QFrame()
+        card.setStyleSheet(_CARD_STYLE)
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(12, 12, 12, 12)
+        card_layout.setSpacing(8)
+
+        # Panel title
+        title = QLabel("📊  Performance")
+        title.setStyleSheet("color: white; font-size: 14px; font-weight: bold;")
+        card_layout.addWidget(title)
+
+        # ── Scrollable inner area (enables adding more metrics freely) ────────
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+            "QScrollBar:vertical { background: rgba(0,0,0,0.2); width: 6px; "
+            "border-radius: 3px; }"
+            "QScrollBar::handle:vertical { background: rgba(255,255,255,0.3); "
+            "border-radius: 3px; }"
+        )
+
+        self._inner = QWidget()
+        self._inner.setStyleSheet("background: transparent;")
+        self._inner_layout = QVBoxLayout(self._inner)
+        self._inner_layout.setContentsMargins(0, 0, 0, 0)
+        self._inner_layout.setSpacing(10)
+
+        scroll.setWidget(self._inner)
+        card_layout.addWidget(scroll)
+        outer.addWidget(card)
+
+        # ── Build placeholder sections (populated on first refresh) ───────────
+        self._donut_container = self._make_section_container()
+        self._priority_container = self._make_section_container()
+        self._overdue_container = self._make_section_container()
+
+        self._inner_layout.addWidget(self._donut_container)
+        self._inner_layout.addWidget(self._priority_container)
+        self._inner_layout.addWidget(self._overdue_container)
+        self._inner_layout.addStretch()
+
+        # Render with zero-data empty state immediately
+        self._render_empty_state()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def refresh(self, task_manager) -> None:
+        """Re-render all metric sections using the latest database snapshot.
+
+        Calls ``task_manager.get_task_stats()`` and pipes the resulting dict
+        into each builder method. Designed to be called at the end of
+        ``DashboardInterface.load_tasks()`` with zero overhead.
+
+        Args:
+            task_manager: An instance of ``business.task_manager.TaskManager``.
+        """
+        stats = task_manager.get_task_stats()
+        self._clear_container(self._donut_container)
+        self._clear_container(self._priority_container)
+        self._clear_container(self._overdue_container)
+
+        if stats["total"] == 0:
+            self._render_empty_state()
+            return
+
+        self._build_donut_section(stats)
+        self._build_priority_bars(stats)
+        self._build_overdue_chip(stats)
+
+    # ── Private builder methods ────────────────────────────────────────────────
+
+    def _build_donut_section(self, stats: dict) -> None:
+        """Render the QPieSeries donut chart into the donut container.
+
+        Creates one pie slice per status (Pending / In Progress / Completed)
+        using glassmorphism-alpha fill colours. Slice labels are hidden to
+        prevent asymmetric outside-label clipping; instead a compact inline
+        legend row with coloured dots is rendered below the chart.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._donut_container.layout()
+
+        lbl = QLabel("COMPLETION RATIO")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        series = QPieSeries()
+        series.setHoleSize(0.58)
+        series.setPieSize(0.80)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            slc = series.append("", count if count > 0 else 0)
+            colour = QColor(bg_hex)
+            colour.setAlpha(200)
+            slc.setBrush(colour)
+            slc.setPen(QColor(0, 0, 0, 0))  # Remove slice border gaps
+            slc.setLabelVisible(False)  # Labels replaced by custom legend row
+
+        chart = QChart()
+        chart.addSeries(series)
+        chart.setBackgroundBrush(QColor(0, 0, 0, 0))
+        chart.setBackgroundRoundness(0)
+        chart.setMargins(QMargins(0, 0, 0, 0))
+        chart.legend().setVisible(False)
+        chart.setAnimationOptions(QChart.AnimationOption.SeriesAnimations)
+
+        view = QChartView(chart)
+        view.setRenderHint(QPainter.RenderHint.Antialiasing)
+        view.setStyleSheet("background: transparent; border: none;")
+        view.setFixedHeight(150)
+        layout.addWidget(view)
+
+        # Custom inline legend: ● Pending 3  ● In Progress 1  ● Done 5
+        legend_row = QHBoxLayout()
+        legend_row.setSpacing(0)
+        legend_row.setContentsMargins(0, 0, 0, 0)
+
+        for status, (bg_hex, _label_hex) in _STATUS_COLOURS.items():
+            count = stats.get(status, 0)
+            short = "Done" if status == "Completed" else status
+
+            dot = QLabel("●")
+            dot.setStyleSheet(
+                f"color: {bg_hex}; font-size: 14px; background: transparent;"
+            )
+            dot.setFixedWidth(18)
+
+            name_count = QLabel(f"{short}  {count}")
+            name_count.setStyleSheet(
+                "color: rgba(255,255,255,0.80); font-size: 10px; background: transparent;"
+            )
+
+            cell = QHBoxLayout()
+            cell.setSpacing(2)
+            cell.setContentsMargins(0, 0, 0, 0)
+            cell.addWidget(dot)
+            cell.addWidget(name_count)
+            cell.addStretch()
+
+            cell_w = QWidget()
+            cell_w.setStyleSheet("background: transparent;")
+            cell_w.setLayout(cell)
+            legend_row.addWidget(cell_w, stretch=1)
+
+        legend_w = QWidget()
+        legend_w.setStyleSheet("background: transparent;")
+        legend_w.setLayout(legend_row)
+        layout.addWidget(legend_w)
+
+    def _build_priority_bars(self, stats: dict) -> None:
+        """Render one styled QProgressBar row per priority level.
+
+        Bar value is expressed as a percentage of total active tasks, giving
+        an instant visual sense of workload distribution. Zero-count priorities
+        are still rendered at 0% to maintain layout consistency.
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._priority_container.layout()
+
+        lbl = QLabel("PRIORITY DISTRIBUTION")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        total = max(stats["total"], 1)  # Guard zero-division
+
+        for priority, hex_colour in _PRIORITY_COLOURS.items():
+            count = stats.get(priority, 0)
+            pct = int((count / total) * 100)
+
+            row = QHBoxLayout()
+            row.setSpacing(8)
+
+            name_lbl = QLabel(priority)
+            name_lbl.setFixedWidth(55)
+            name_lbl.setStyleSheet("color: rgba(255,255,255,0.75); font-size: 11px;")
+            row.addWidget(name_lbl)
+
+            bar = QProgressBar()
+            bar.setRange(0, 100)
+            bar.setValue(pct)
+            bar.setTextVisible(False)
+            bar.setFixedHeight(8)
+            bar.setStyleSheet(f"""
+                QProgressBar {{
+                    background-color: rgba(255,255,255,0.1);
+                    border-radius: 4px;
+                    border: none;
+                }}
+                QProgressBar::chunk {{
+                    background-color: {hex_colour};
+                    border-radius: 4px;
+                }}
+            """)
+            row.addWidget(bar, stretch=1)
+
+            count_lbl = QLabel(str(count))
+            count_lbl.setFixedWidth(18)
+            count_lbl.setStyleSheet(
+                "color: rgba(255,255,255,0.55); font-size: 11px; font-weight: bold;"
+            )
+            count_lbl.setAlignment(
+                Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+            )
+            row.addWidget(count_lbl)
+
+            row_w = QWidget()
+            row_w.setStyleSheet("background: transparent;")
+            row_w.setLayout(row)
+            layout.addWidget(row_w)
+
+    def _build_overdue_chip(self, stats: dict) -> None:
+        """Render the overdue KPI pill badge into the overdue container.
+
+        Displays a red warning pill when overdue tasks exist, or a calm
+        green confirmation chip when all tasks are within schedule. Reuses
+        the same due-date detection logic established in FT04 (urgency UI).
+
+        Args:
+            stats: Aggregate dict from ``TaskManager.get_task_stats()``.
+        """
+        layout = self._overdue_container.layout()
+
+        lbl = QLabel("OVERDUE STATUS")
+        lbl.setStyleSheet(_SECTION_TITLE_STYLE)
+        layout.addWidget(lbl)
+
+        overdue = stats.get("overdue", 0)
+
+        if overdue > 0:
+            text = f"⚠  {overdue} task{'s' if overdue > 1 else ''} overdue"
+            chip_style = (
+                "background-color: rgba(255, 77, 77, 0.25); "
+                "color: #FF4D4D; "
+                "border: 1px solid rgba(255, 77, 77, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+        else:
+            text = "✓  All tasks on schedule"
+            chip_style = (
+                "background-color: rgba(40, 91, 35, 0.3); "
+                "color: #A8D5A2; "
+                "border: 1px solid rgba(40, 91, 35, 0.5); "
+                "border-radius: 10px; padding: 6px 12px; font-size: 12px; font-weight: bold;"
+            )
+
+        chip = QLabel(text)
+        chip.setStyleSheet(chip_style)
+        chip.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        chip.setObjectName("overdue_chip")
+        layout.addWidget(chip)
+
+    def _render_empty_state(self) -> None:
+        """Render a friendly placeholder when the task database is empty.
+
+        Called on first initialisation and whenever refresh() receives a
+        zero-task stats dict. Clears all three containers and injects a
+        single centred label with premium typography.
+        """
+        for container in (
+            self._donut_container,
+            self._priority_container,
+            self._overdue_container,
+        ):
+            self._clear_container(container)
+
+        layout = self._donut_container.layout()
+        empty_lbl = QLabel("No tasks yet\nStart planning to see insights!")
+        empty_lbl.setStyleSheet(
+            "color: rgba(255,255,255,0.35); font-size: 13px; font-style: italic;"
+        )
+        empty_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        empty_lbl.setObjectName("empty_state_label")
+        layout.addWidget(empty_lbl)
+
+    # ── Helpers ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _make_section_container() -> QFrame:
+        """Create a transparent QFrame used as a section slot in the scroll area.
+
+        Returns:
+            QFrame: An empty container with a vertical layout and no border.
+        """
+        frame = QFrame()
+        frame.setStyleSheet("QFrame { background: transparent; border: none; }")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        return frame
+
+    @staticmethod
+    def _clear_container(container: QFrame) -> None:
+        """Remove all child widgets from a section container without memory leaks.
+
+        Uses ``deleteLater()`` to safely schedule PySide6 widget destruction
+        on the next event-loop cycle, preventing dangling C++ object references.
+
+        Args:
+            container: The QFrame whose layout children will be cleared.
+        """
+        layout = container.layout()
+        while layout.count():
+            child = layout.takeAt(0)
+            widget = child.widget()
+            if widget:
+                widget.deleteLater()

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -563,9 +563,8 @@ class DashboardInterface(QWidget):
 
         self.analytics_widget = AnalyticsWidget()
 
-        right_panel_layout.addWidget(calendar_card)
-        right_panel_layout.addWidget(self.analytics_widget)
-        right_panel_layout.addStretch()
+        right_panel_layout.addWidget(calendar_card, stretch=0)
+        right_panel_layout.addWidget(self.analytics_widget, stretch=1)
 
         dash_main_layout.addLayout(task_section_layout, 3)
         dash_main_layout.addLayout(right_panel_layout, 2)

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 
 from PySide6.QtCore import (
-    QDate,
     QSize,
     Qt,
 )
@@ -122,19 +121,29 @@ class KanbanCard(QFrame):
             return " ".join(shattered)
 
         # --------- URGENCY BORDER OVERRIDE ---------
-        from PySide6.QtCore import QDate
+        from PySide6.QtCore import QDateTime
 
         def is_task_urgent(t):
             if t.status == "Completed":
                 return False
             if not t.due_date:
                 return False
-            parsed_date = QDate.fromString(
-                str(t.due_date).strip(), Qt.DateFormat.ISODate
-            )
-            if not parsed_date.isValid():
-                return False
-            return QDate.currentDate().daysTo(parsed_date) <= 2
+
+            due_str = str(t.due_date).strip()
+            parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+
+            # Fallback to date-only if parsing failed (legacy tasks)
+            if not parsed_dt.isValid():
+                parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                if not parsed_d.isValid():
+                    return False
+                parsed_dt = QDateTime(parsed_d, QDateTime.currentDateTime().time())
+
+            # Urgent if it's due within 48 hours
+            secs_to = QDateTime.currentDateTime().secsTo(parsed_dt)
+            return (
+                secs_to <= (2 * 24 * 3600) and secs_to > -86400
+            )  # Between yesterday and 48 hours from now
 
         border_css = (
             "border-left: 5px solid #FF4D4D;"
@@ -190,8 +199,23 @@ class KanbanCard(QFrame):
 
         # 4. Footer Row (Due Date)
         if task.due_date:
+            from PySide6.QtCore import QDate, QDateTime
+
+            due_str = str(task.due_date).strip()
+
+            # Format nicely
+            parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+            if parsed_dt.isValid():
+                display_str = parsed_dt.toString("MMM d, yyyy - h:mm AP")
+            else:
+                parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                if parsed_d.isValid():
+                    display_str = parsed_d.toString("MMM d, yyyy")
+                else:
+                    display_str = due_str
+
             footer_layout = QHBoxLayout()
-            due_lbl = QLabel(f"📅 {task.due_date}")
+            due_lbl = QLabel(f"📅 {display_str}")
             due_lbl.setStyleSheet("font-size: 12px; font-weight: bold; opacity: 0.8;")
             footer_layout.addWidget(due_lbl)
             footer_layout.addStretch()
@@ -519,12 +543,10 @@ class DashboardInterface(QWidget):
         header = self.task_tree.header()
         header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)  # Task Title
         header.setSectionResizeMode(
-            1, QHeaderView.ResizeMode.ResizeToContents
-        )  # Due Date
+            1, QHeaderView.ResizeMode.Fixed
+        )  # Due Date — Fixed so centering works
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)  # Priority
-        self.task_tree.setColumnWidth(
-            1, 140
-        )  # Locks the column strictly so it never balloons
+        self.task_tree.setColumnWidth(1, 200)  # Wide enough for "MMM d, yy - h:mm AP"
         self.task_tree.setColumnWidth(2, 90)
 
         # Right-Click Menu Support Integration
@@ -812,20 +834,27 @@ class DashboardInterface(QWidget):
         tasks = self.task_manager.get_all_tasks(db_query)
 
         # --------- CORE URGENCY ALGORITHM ---------
+        from PySide6.QtCore import QDateTime
+
         def is_task_urgent(t):
             if t.status == "Completed":
                 return False
             if not t.due_date:
                 return False
-            parsed_date = QDate.fromString(
-                str(t.due_date).strip(), Qt.DateFormat.ISODate
-            )
-            if not parsed_date.isValid():
-                return False
-            days_to_due = QDate.currentDate().daysTo(parsed_date)
-            return (
-                days_to_due <= 2
-            )  # Anything overdue or within 48 hours is considered an emergency
+
+            due_str = str(t.due_date).strip()
+            parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+
+            # Fallback to date-only if parsing failed (legacy tasks)
+            if not parsed_dt.isValid():
+                parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                if not parsed_d.isValid():
+                    return False
+                parsed_dt = QDateTime(parsed_d, QDateTime.currentDateTime().time())
+
+            # Urgent if it's due within 48 hours
+            secs_to = QDateTime.currentDateTime().secsTo(parsed_dt)
+            return secs_to <= (2 * 24 * 3600) and secs_to > -86400
 
         # Intercept the database pull and artificially slice it if the banner was clicked
         if query == "is:urgent":
@@ -926,6 +955,9 @@ class DashboardInterface(QWidget):
                     inline_header.setFont(col, inline_font)  # Applies the bigger font
 
                 inline_header.setTextAlignment(
+                    1, Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter
+                )
+                inline_header.setTextAlignment(
                     2, Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
                 )
                 grp.addChild(inline_header)
@@ -938,11 +970,26 @@ class DashboardInterface(QWidget):
                 else:
                     parent_grp = todo_group
 
+                display_str = "--"
+                if task.due_date:
+                    from PySide6.QtCore import QDateTime, QDate
+
+                    due_str = str(task.due_date).strip()
+                    parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+                    if parsed_dt.isValid():
+                        display_str = parsed_dt.toString("MMM d, yy - h:mm AP")
+                    else:
+                        parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                        if parsed_d.isValid():
+                            display_str = parsed_d.toString("MMM d, yy")
+                        else:
+                            display_str = due_str
+
                 # 3. Build the Raw Text Row
                 row_item = QTreeWidgetItem(
                     [
                         task.title,
-                        task.due_date if task.due_date else "--",
+                        display_str,
                         task.priority,
                     ]
                 )
@@ -978,7 +1025,7 @@ class DashboardInterface(QWidget):
                 )  # transparent — badge widget paints this
 
                 row_item.setTextAlignment(
-                    1, Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+                    1, Qt.AlignmentFlag.AlignCenter | Qt.AlignmentFlag.AlignVCenter
                 )
 
                 # --------- LEFT BORDER INJECTION ---------

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -30,6 +30,7 @@ from business.task_manager import TaskManager
 from data.models import Task
 from presentation.analytics_widget import AnalyticsWidget
 from presentation.task_editor_dialog import TaskEditorDialog
+from presentation.trash_widget import TrashWidget
 
 try:
     from config import get_default_db_path
@@ -201,7 +202,9 @@ class KanbanCard(QFrame):
         self.customContextMenuRequested.connect(self.show_menu)
 
     def show_menu(self, pos):
-        # Passes control securely back to the Dashboard Controller
+        """
+        Passes control securely back to the Dashboard Controller
+        """
         self.dashboard.show_kanban_context_menu(self.task, self.mapToGlobal(pos))
 
     def sizeHint(self):
@@ -227,6 +230,13 @@ class DashboardInterface(QWidget):
     """
 
     def __init__(self, parent=None, db_file=None):
+        """
+        Initializes the DashboardInterface with the given parent and database file path.
+
+        Args:
+            parent (QWidget): The parent widget of this widget.
+            db_file (str): The path to the SQLite database file.
+        """
         super().__init__(parent=parent)
         self.setObjectName("DashboardInterface")
 
@@ -271,8 +281,13 @@ class DashboardInterface(QWidget):
         self.update_background()
         self.load_tasks()
 
-    # Window Resizing Engines (Paste directly under __init__)
     def resizeEvent(self, event):
+        """
+        Overrides the default resize event to handle window resizing.
+
+        Args:
+            event (QResizeEvent): The resize event.
+        """
         self.update_background()
         super().resizeEvent(event)
 
@@ -742,6 +757,9 @@ class DashboardInterface(QWidget):
         self.content_stack.addWidget(self.page_dashboard)  # Index 0
         self.content_stack.addWidget(self.page_kanban)  # Index 1
 
+        self.page_trash = TrashWidget(self)
+        self.content_stack.addWidget(self.page_trash)  # Index 2
+
         self.main_layout.addWidget(self.sidebar)
         self.main_layout.addWidget(self.content_stack, stretch=1)
 
@@ -790,11 +808,8 @@ class DashboardInterface(QWidget):
         # Prevent SQLite from trying to literally search for "is:urgent" in the Title
         db_query = "" if query == "is:urgent" else query
 
-        # 3. Pull from standard DB or Trash DB
-        if self.current_mode == "trash":
-            tasks = self.task_manager.get_deleted_tasks(db_query)
-        else:
-            tasks = self.task_manager.get_all_tasks(db_query)
+        # 3. Pull from standard DB
+        tasks = self.task_manager.get_all_tasks(db_query)
 
         # --------- CORE URGENCY ALGORITHM ---------
         def is_task_urgent(t):
@@ -1025,7 +1040,7 @@ class DashboardInterface(QWidget):
 
         # Refresh analytics panel so charts always mirror current task state
         if hasattr(self, "analytics_widget"):
-            self.analytics_widget.refresh(self.task_manager)
+            self.analytics_widget.refresh(self.task_manager, tasks)
 
     def show_kanban_context_menu(self, task, global_pos):
         """
@@ -1286,18 +1301,17 @@ class DashboardInterface(QWidget):
         if mode == "trash":
             self.title_label.setText("Trash Bin")
             self.add_btn.hide()
-            self.content_stack.setCurrentIndex(
-                0
-            )  # Trash shows via the Dashboard layout
+            self.content_stack.setCurrentIndex(2)  # TrashWidget
+            self.page_trash.refresh()
         elif mode == "active":
             self.title_label.setText("My Tasks")
             self.add_btn.show()
             self.content_stack.setCurrentIndex(0)  # Dashboard Profile
+            self.load_tasks()
         elif mode == "kanban":
             # Swaps the screen purely to the massive Kanban Board!
             self.content_stack.setCurrentIndex(1)
-
-        self.load_tasks()
+            self.load_tasks()
 
     def toggle_group_expansion(self, item, column):
         """

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from business.task_manager import TaskManager
 from data.models import Task
+from presentation.analytics_widget import AnalyticsWidget
 from presentation.task_editor_dialog import TaskEditorDialog
 
 try:
@@ -560,16 +561,10 @@ class DashboardInterface(QWidget):
 
         cal_layout.addWidget(calendar)
 
-        performance_card = QFrame()
-        performance_card.setStyleSheet("""QFrame {
-        background-color: rgba(0,0,0,0.5);
-        border-radius: 20px;
-        padding: 15px;
-        }""")
+        self.analytics_widget = AnalyticsWidget()
 
-        right_panel_layout.addWidget(calendar_card)
-        right_panel_layout.addWidget(performance_card)
-        right_panel_layout.addStretch()
+        right_panel_layout.addWidget(calendar_card, stretch=0)
+        right_panel_layout.addWidget(self.analytics_widget, stretch=1)
 
         dash_main_layout.addLayout(task_section_layout, 3)
         dash_main_layout.addLayout(right_panel_layout, 2)
@@ -1027,6 +1022,10 @@ class DashboardInterface(QWidget):
 
                 self.task_tree.setItemWidget(row_item, 2, badge_container)
                 # -------------------------------------------------------------------------
+
+        # Refresh analytics panel so charts always mirror current task state
+        if hasattr(self, "analytics_widget"):
+            self.analytics_widget.refresh(self.task_manager)
 
     def show_kanban_context_menu(self, task, global_pos):
         """

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -28,6 +28,7 @@ from PySide6.QtWidgets import (
 
 from business.task_manager import TaskManager
 from data.models import Task
+from presentation.analytics_widget import AnalyticsWidget
 from presentation.task_editor_dialog import TaskEditorDialog
 
 try:
@@ -560,15 +561,10 @@ class DashboardInterface(QWidget):
 
         cal_layout.addWidget(calendar)
 
-        performance_card = QFrame()
-        performance_card.setStyleSheet("""QFrame {
-        background-color: rgba(0,0,0,0.5);
-        border-radius: 20px;
-        padding: 15px;
-        }""")
+        self.analytics_widget = AnalyticsWidget()
 
         right_panel_layout.addWidget(calendar_card)
-        right_panel_layout.addWidget(performance_card)
+        right_panel_layout.addWidget(self.analytics_widget)
         right_panel_layout.addStretch()
 
         dash_main_layout.addLayout(task_section_layout, 3)
@@ -1027,6 +1023,10 @@ class DashboardInterface(QWidget):
 
                 self.task_tree.setItemWidget(row_item, 2, badge_container)
                 # -------------------------------------------------------------------------
+
+        # Refresh analytics panel so charts always mirror current task state
+        if hasattr(self, "analytics_widget"):
+            self.analytics_widget.refresh(self.task_manager)
 
     def show_kanban_context_menu(self, task, global_pos):
         """

--- a/src/presentation/dashboard.py
+++ b/src/presentation/dashboard.py
@@ -58,6 +58,50 @@ ACTIVE_THEME_MAP = {
 }
 
 
+def format_due_countdown(due_date_str, status: str = "") -> str | None:
+    """
+    Returns a short human-readable countdown tooltip for a task's due date.
+    Scales: minutes → hours → days.
+    Returns None for Completed tasks or tasks with no due date.
+    """
+    if not due_date_str or status == "Completed":
+        return None
+
+    due_str = str(due_date_str).strip()
+    try:
+        due_dt = datetime.fromisoformat(due_str)
+    except ValueError:
+        try:
+            # Legacy date-only: assume end of day
+            due_dt = datetime.strptime(due_str, "%Y-%m-%d").replace(
+                hour=23, minute=59, second=59
+            )
+        except ValueError:
+            return None
+
+    delta = due_dt - datetime.now()
+    total_seconds = delta.total_seconds()
+
+    if total_seconds < 0:
+        abs_s = abs(total_seconds)
+        if abs_s < 3600:
+            return f"⚠️ Overdue by {int(abs_s // 60)}m"
+        elif abs_s < 86400:
+            return f"⚠️ Overdue by {int(abs_s // 3600)}h"
+        else:
+            return f"⚠️ Overdue by {int(abs_s // 86400)}d"
+    elif total_seconds < 3600:
+        return f"⏰ Due in {max(1, int(total_seconds // 60))}m"
+    elif total_seconds < 86400:
+        return f"⏰ Due in {int(total_seconds // 3600)}h"
+    else:
+        # Always show days for future tasks — urgent window gets ⏰, others get 📅
+        days = int(total_seconds // 86400)
+        if days <= 3:
+            return f"⏰ Due in {days}d"
+        return f"📅 Due in {days}d"
+
+
 class KanbanCard(QFrame):
     """
     Custom QFrame GUI component representing a single task in the Kanban board.
@@ -221,7 +265,12 @@ class KanbanCard(QFrame):
             footer_layout.addStretch()
             layout.addLayout(footer_layout)
 
-        # 5. Context Menu Engine Integration
+        # 5. Countdown Tooltip
+        countdown = format_due_countdown(task.due_date, task.status)
+        if countdown:
+            self.setToolTip(countdown)
+
+        # 6. Context Menu Engine Integration
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self.show_menu)
 
@@ -996,6 +1045,12 @@ class DashboardInterface(QWidget):
                 row_item.setSizeHint(0, QSize(0, 32))
 
                 row_item.setData(0, Qt.ItemDataRole.UserRole, task.id)
+
+                # Countdown tooltip — spread across all columns so hovering anywhere on the row shows it
+                countdown = format_due_countdown(task.due_date, task.status)
+                if countdown:
+                    for col in range(3):
+                        row_item.setToolTip(col, countdown)
 
                 # NATIVE PASTEL UI
                 bg_hex = (

--- a/src/presentation/task_editor_dialog.py
+++ b/src/presentation/task_editor_dialog.py
@@ -4,45 +4,88 @@ from PySide6.QtWidgets import (
     QComboBox,
     QDateEdit,
     QDialog,
-    QDialogButtonBox,
     QGraphicsDropShadowEffect,
+    QGridLayout,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
+    QPushButton,
     QTextEdit,
     QVBoxLayout,
 )
+
+_DIALOG_STYLE = """
+    QDialog {
+        background-color: #1E2328;
+    }
+    QLabel {
+        color: #FFFFFF;
+        font-weight: bold;
+        font-size: 13px;
+    }
+    QLineEdit, QTextEdit, QDateEdit, QComboBox {
+        background-color: rgba(255, 255, 255, 0.05);
+        color: white;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 6px;
+        padding: 8px 12px;
+        font-size: 14px;
+    }
+    QLineEdit:focus, QTextEdit:focus, QDateEdit:focus, QComboBox:focus {
+        border: 1px solid #6579BE;
+        background-color: rgba(255, 255, 255, 0.08);
+    }
+    /* Disable calendar popup weird styling */
+    QCalendarWidget QWidget {
+        alternate-background-color: #2F3239;
+    }
+"""
 
 
 class TaskEditorDialog(QDialog):
     def __init__(self, parent=None, task=None):
         super().__init__(parent)
-        self.setWindowTitle("Edit Task" if task else "Add New Task")
-        self.setMinimumWidth(400)
+        self.setWindowTitle("Edit Task" if task else "Create New Task")
+        self.setMinimumWidth(500)
+        self.setStyleSheet(_DIALOG_STYLE)
         self.task = task
 
         layout = QVBoxLayout(self)
+        layout.setSpacing(15)
+        layout.setContentsMargins(25, 25, 25, 25)
 
         # Initialize floating toast (does not get added to layout)
         self.toast = ToastNotification(self)
 
-        # Title
-        layout.addWidget(QLabel("Title (Required):"))
+        # 1. Header
+        header_lbl = QLabel("✏️ Edit Task" if task else "✨ Create New Task")
+        header_lbl.setStyleSheet("font-size: 22px; font-weight: bold; color: white;")
+        layout.addWidget(header_lbl)
+
+        # 2. Main Inputs (Title & Description)
+        layout.addWidget(QLabel("Task Title (Required)"))
         self.title_input = QLineEdit()
+        self.title_input.setPlaceholderText("e.g. Prepare Q3 Marketing Report")
         if task:
             self.title_input.setText(task.title)
         layout.addWidget(self.title_input)
 
-        # Description
-        layout.addWidget(QLabel("Description:"))
+        layout.addWidget(QLabel("Task Description"))
         self.desc_input = QTextEdit()
-        self.desc_input.setMaximumHeight(100)
+        self.desc_input.setPlaceholderText("Add any relevant context or notes here...")
+        self.desc_input.setMaximumHeight(80)
         if task:
             self.desc_input.setText(task.description or "")
         layout.addWidget(self.desc_input)
 
-        # Due Date
-        layout.addWidget(QLabel("Due Date:"))
+        # 3. Metadata Grid (2x2)
+        grid = QGridLayout()
+        grid.setSpacing(15)
+
+        # Row 0, Col 0: Due Date
+        grid.addWidget(QLabel("Due Date"), 0, 0)
         self.date_input = QDateEdit()
+        self.date_input.setCalendarPopup(True)
         if task and task.due_date:
             due_str = str(task.due_date).strip()
             if due_str:
@@ -55,23 +98,31 @@ class TaskEditorDialog(QDialog):
                 self.date_input.setDate(QDate.currentDate())
         else:
             self.date_input.setDate(QDate.currentDate())
-        self.date_input.setCalendarPopup(True)
-        layout.addWidget(self.date_input)
+        grid.addWidget(self.date_input, 1, 0)
 
-        # Priority
-        layout.addWidget(QLabel("Priority:"))
+        # Row 0, Col 1: Priority
+        grid.addWidget(QLabel("Priority"), 0, 1)
         self.priority_input = QComboBox()
         self.priority_input.addItems(["Low", "Medium", "High", "Critical"])
         if task and task.priority:
             index = self.priority_input.findText(task.priority)
             if index >= 0:
                 self.priority_input.setCurrentIndex(index)
-        layout.addWidget(self.priority_input)
+        grid.addWidget(self.priority_input, 1, 1)
 
-        # Color
-        layout.addWidget(QLabel("Task Color:"))
+        # Row 2, Col 0: Status
+        grid.addWidget(QLabel("Status"), 2, 0)
+        self.status_input = QComboBox()
+        self.status_input.addItems(["Pending", "In Progress", "Completed"])
+        if task and hasattr(task, "status"):
+            index = self.status_input.findText(task.status)
+            if index >= 0:
+                self.status_input.setCurrentIndex(index)
+        grid.addWidget(self.status_input, 3, 0)
+
+        # Row 2, Col 1: Color Theme
+        grid.addWidget(QLabel("Theme Color"), 2, 1)
         self.color_combo = QComboBox()
-        # Original Soft Themes
         self.color_combo.addItem("🌊 Ocean Peach", "#6579BE")
         self.color_combo.addItem("🏜️ Warm Sand", "#E9DFD8")
         self.color_combo.addItem("🔥 Vibrant Orange", "#F54800")
@@ -81,12 +132,8 @@ class TaskEditorDialog(QDialog):
         self.color_combo.addItem("🐋 Deep Ocean", "#19485F")
         self.color_combo.addItem("🌲 Forest Pink", "#285B23")
         self.color_combo.addItem("🥀 Dusty Rose", "#92736C")
-
-        # New High-Contrast & Solid Themes
         self.color_combo.addItem("🌑 Pitch Black (White Text)", "#000000")
         self.color_combo.addItem("🌕 Pure White (Black Text)", "#FFFFFF")
-
-        # We use slight micro-shades of White/Black to keep Python Dictionaries happy
         self.color_combo.addItem("🌫️ Frost White (Gray Text)", "#FFFFFE")
         self.color_combo.addItem("☁️ Light Gray (White Text)", "#DDDDDD")
         self.color_combo.addItem("🥶 Ice White (Blue Text)", "#FFFFFD")
@@ -97,15 +144,41 @@ class TaskEditorDialog(QDialog):
             index = self.color_combo.findData(task.color)
             if index >= 0:
                 self.color_combo.setCurrentIndex(index)
-        layout.addWidget(self.color_combo)
+        grid.addWidget(self.color_combo, 3, 1)
 
-        # Buttons
-        self.button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
-        )
-        self.button_box.accepted.connect(self.validate_and_accept)
-        self.button_box.rejected.connect(self.reject)
-        layout.addWidget(self.button_box)
+        layout.addLayout(grid)
+        layout.addSpacing(10)
+
+        # 4. Action Footer (Save / Cancel)
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.cancel_btn.setStyleSheet("""
+            QPushButton {
+                background-color: transparent;
+                color: #A0A0A0; font-weight: bold; padding: 10px 20px; border-radius: 6px;
+            }
+            QPushButton:hover { background-color: rgba(255, 255, 255, 0.05); color: white; }
+        """)
+        self.cancel_btn.clicked.connect(self.reject)
+
+        self.save_btn = QPushButton("Save Task")
+        self.save_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.save_btn.setStyleSheet("""
+            QPushButton {
+                background-color: rgba(40, 91, 35, 0.85);
+                color: white; font-weight: bold; padding: 10px 24px; border-radius: 6px;
+            }
+            QPushButton:hover { background-color: rgba(40, 91, 35, 1.0); }
+        """)
+        self.save_btn.clicked.connect(self.validate_and_accept)
+
+        btn_layout.addWidget(self.cancel_btn)
+        btn_layout.addWidget(self.save_btn)
+
+        layout.addLayout(btn_layout)
 
     def validate_and_accept(self):
         title = self.title_input.text().strip()
@@ -145,7 +218,7 @@ class TaskEditorDialog(QDialog):
             "description": self.desc_input.toPlainText().strip(),
             "due_date": self.date_input.date().toString(Qt.DateFormat.ISODate),
             "priority": self.priority_input.currentText(),
-            "status": self.task.status if self.task else "Pending",
+            "status": self.status_input.currentText(),
             "color": self.color_combo.currentData(),  # Extract the hidden Hex Code
         }
 

--- a/src/presentation/task_editor_dialog.py
+++ b/src/presentation/task_editor_dialog.py
@@ -1,4 +1,13 @@
-from PySide6.QtCore import QDate, QEasingCurve, QPoint, QPropertyAnimation, Qt, QTimer
+from PySide6.QtCore import (
+    QDate,
+    QDateTime,
+    QEasingCurve,
+    QPoint,
+    QPropertyAnimation,
+    Qt,
+    QTime,
+    QTimer,
+)
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QComboBox,
@@ -82,23 +91,57 @@ class TaskEditorDialog(QDialog):
         grid = QGridLayout()
         grid.setSpacing(15)
 
-        # Row 0, Col 0: Due Date
-        grid.addWidget(QLabel("Due Date"), 0, 0)
+        # Row 0, Col 0: Due Date & Time
+        grid.addWidget(QLabel("Due Date & Time"), 0, 0)
+
+        datetime_layout = QHBoxLayout()
+        datetime_layout.setSpacing(5)
+
         self.date_input = QDateEdit()
         self.date_input.setCalendarPopup(True)
+
+        self.time_input = QComboBox()
+        # Generate 30-minute intervals
+        times = []
+        for h in range(24):
+            for m in (0, 30):
+                qtime = QTime(h, m)
+                times.append(qtime.toString("hh:mm AP"))
+        self.time_input.addItems(times)
+
         if task and task.due_date:
             due_str = str(task.due_date).strip()
             if due_str:
-                parsed = QDate.fromString(due_str, Qt.DateFormat.ISODate)
-                if parsed.isValid():
-                    self.date_input.setDate(parsed)
+                parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+                if parsed_dt.isValid():
+                    self.date_input.setDate(parsed_dt.date())
+                    # Snap to nearest 30 mins or just match exact if exists
+                    time_str = parsed_dt.time().toString("hh:mm AP")
+                    idx = self.time_input.findText(time_str)
+                    if idx >= 0:
+                        self.time_input.setCurrentIndex(idx)
+                    else:
+                        # If weird time, just append it
+                        self.time_input.addItem(time_str)
+                        self.time_input.setCurrentIndex(self.time_input.count() - 1)
                 else:
-                    self.date_input.setDate(QDate.currentDate())
+                    parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                    if parsed_d.isValid():
+                        self.date_input.setDate(parsed_d)
+                        self.time_input.setCurrentText("11:30 PM")
+                    else:
+                        self.date_input.setDate(QDate.currentDate())
+                        self.time_input.setCurrentText("11:30 PM")
             else:
                 self.date_input.setDate(QDate.currentDate())
+                self.time_input.setCurrentText("11:30 PM")
         else:
             self.date_input.setDate(QDate.currentDate())
-        grid.addWidget(self.date_input, 1, 0)
+            self.time_input.setCurrentText("11:30 PM")
+
+        datetime_layout.addWidget(self.date_input, stretch=2)
+        datetime_layout.addWidget(self.time_input, stretch=1)
+        grid.addLayout(datetime_layout, 1, 0)
 
         # Row 0, Col 1: Priority
         grid.addWidget(QLabel("Priority"), 0, 1)
@@ -180,6 +223,14 @@ class TaskEditorDialog(QDialog):
 
         layout.addLayout(btn_layout)
 
+    def _get_selected_datetime(self):
+        """Helper to combine the DateEdit and TimeComboBox into a single QDateTime"""
+        d = self.date_input.date()
+        t = QTime.fromString(self.time_input.currentText(), "hh:mm AP")
+        if not t.isValid():
+            t = QTime(23, 59, 59)
+        return QDateTime(d, t)
+
     def validate_and_accept(self):
         title = self.title_input.text().strip()
 
@@ -187,25 +238,30 @@ class TaskEditorDialog(QDialog):
             self.toast.show_toast("Title is required!")
             return
 
-        # --- PAST DUE DATE VALIDATION ---
-        selected_date = self.date_input.date()
-        current_date = QDate.currentDate()
+        # --- PAST DUE DATETIME VALIDATION ---
+        selected_dt = self._get_selected_datetime()
+        current_dt = QDateTime.currentDateTime()
 
-        # Check if the currently selected date is in the past
-        if selected_date < current_date:
-            original_date = None
+        # Check if the currently selected datetime is in the past
+        if selected_dt < current_dt:
+            original_dt = None
 
-            # Identify if we are editing an existing task, and if so, capture its original date
+            # Identify if we are editing an existing task, and if so, capture its original datetime
             if self.task and self.task.due_date:
                 due_str = str(self.task.due_date).strip()
                 if due_str:
-                    parsed = QDate.fromString(due_str, Qt.DateFormat.ISODate)
-                    if parsed.isValid():
-                        original_date = parsed
+                    parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+                    if parsed_dt.isValid():
+                        original_dt = parsed_dt
+                    else:
+                        # Legacy fallback parsing for comparison
+                        parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                        if parsed_d.isValid():
+                            original_dt = QDateTime(parsed_d, QTime(23, 59, 59))
 
-            # If it's a NEW task, OR they changed the date to a NEW past date, block the save
-            if not original_date or selected_date != original_date:
-                self.toast.show_toast("Due Date cannot be in the past!")
+            # If it's a NEW task, OR they changed the datetime to a NEW past datetime, block the save
+            if not original_dt or selected_dt != original_dt:
+                self.toast.show_toast("Due Date/Time cannot be in the past!")
                 return
         # --------------------------------
 
@@ -216,7 +272,7 @@ class TaskEditorDialog(QDialog):
         return {
             "title": self.title_input.text().strip(),
             "description": self.desc_input.toPlainText().strip(),
-            "due_date": self.date_input.date().toString(Qt.DateFormat.ISODate),
+            "due_date": self._get_selected_datetime().toString(Qt.DateFormat.ISODate),
             "priority": self.priority_input.currentText(),
             "status": self.status_input.currentText(),
             "color": self.color_combo.currentData(),  # Extract the hidden Hex Code

--- a/src/presentation/trash_widget.py
+++ b/src/presentation/trash_widget.py
@@ -106,12 +106,12 @@ class TrashWidget(QWidget):
         )
 
         header = self.task_tree.header()
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
-        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)
-        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Fixed)
-        self.task_tree.setColumnWidth(2, 120)
-        self.task_tree.setColumnWidth(3, 90)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)  # #
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Title
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)  # Due Date
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Fixed)  # Priority
+        self.task_tree.setColumnWidth(2, 200)  # Wide enough for "Apr 30, 26 - 12:00 AM"
+        self.task_tree.setColumnWidth(3, 100)
 
         self.task_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.task_tree.customContextMenuRequested.connect(self.show_context_menu)
@@ -127,11 +127,26 @@ class TrashWidget(QWidget):
         tasks = self.task_manager.get_deleted_tasks(query)
 
         for index, task in enumerate(tasks, start=1):
+            display_str = "--"
+            if task.due_date:
+                from PySide6.QtCore import QDate, QDateTime
+
+                due_str = str(task.due_date).strip()
+                parsed_dt = QDateTime.fromString(due_str, Qt.DateFormat.ISODate)
+                if parsed_dt.isValid():
+                    display_str = parsed_dt.toString("MMM d, yy - h:mm AP")
+                else:
+                    parsed_d = QDate.fromString(due_str, Qt.DateFormat.ISODate)
+                    if parsed_d.isValid():
+                        display_str = parsed_d.toString("MMM d, yy")
+                    else:
+                        display_str = due_str
+
             row_item = QTreeWidgetItem(
                 [
                     str(index),  # Column 0: The Row Number
                     task.title,  # Column 1: The Raw Title
-                    task.due_date if task.due_date else "--",  # Column 2: Date
+                    display_str,  # Column 2: Date & Time
                     task.priority,  # Column 3: Priority
                 ]
             )
@@ -152,8 +167,12 @@ class TrashWidget(QWidget):
                 row_item.setBackground(col, pastel)
 
             row_item.setForeground(1, QColor(fg_hex))
+            row_item.setForeground(2, QColor(fg_hex))
             row_item.setTextAlignment(
                 1, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+            )
+            row_item.setTextAlignment(
+                2, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
             )
 
             # Priority Badge Setup (similar to Kanban)
@@ -166,9 +185,9 @@ class TrashWidget(QWidget):
 
             badge_container = QWidget()
             badge_layout = QHBoxLayout(badge_container)
-            badge_layout.setContentsMargins(30, 0, 5, 0)
-            badge_layout.addStretch()
+            badge_layout.setContentsMargins(5, 0, 0, 0)
             badge_layout.addWidget(badge)
+            badge_layout.addStretch()
 
             # Title Setup
             title_container = QWidget()

--- a/src/presentation/trash_widget.py
+++ b/src/presentation/trash_widget.py
@@ -1,0 +1,225 @@
+"""
+Trash Widget for the Efficio Dashboard.
+
+Provides a self-contained QWidget that renders deleted tasks in a styled QTreeWidget.
+Handles its own search bar and context menu (Restore, Permanently Delete).
+
+ISO 25010 Compliance:
+    - Modifiability: Extracts the trash view from the Dashboard god class.
+"""
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMenu,
+    QMessageBox,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class TrashWidget(QWidget):
+    """Self-contained Trash Bin view for the Efficio Dashboard.
+
+    Renders deleted tasks and provides context menu actions for restoration
+    and permanent deletion.
+    """
+
+    def __init__(self, dashboard) -> None:
+        """Initialise the widget and build layout.
+
+        Args:
+            dashboard: The main DashboardInterface (for access to task_manager and load_tasks).
+        """
+        super().__init__()
+        self.dashboard = dashboard
+        self.task_manager = dashboard.task_manager
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 20, 20, 20)
+        layout.setSpacing(15)
+
+        # ── Header ──────────────────────────────────────────────────────────
+        header_layout = QHBoxLayout()
+        title_label = QLabel("🗑️ Trash Bin")
+        title_label.setStyleSheet("font-size: 26px; font-weight: bold; color: white;")
+        header_layout.addWidget(title_label)
+        header_layout.addStretch()
+
+        self.search_bar = QLineEdit()
+        self.search_bar.setPlaceholderText("Search deleted tasks...")
+        self.search_bar.setFixedWidth(250)
+        self.search_bar.setStyleSheet(
+            "padding: 8px; border-radius: 10px; background-color: rgba(255,255,255,0.1); color: white;"
+        )
+        self.search_bar.textChanged.connect(self.refresh)
+        header_layout.addWidget(self.search_bar)
+
+        layout.addLayout(header_layout)
+
+        # ── Tree Widget ─────────────────────────────────────────────────────
+        self.task_tree = QTreeWidget()
+        self.task_tree.setHeaderHidden(False)
+        self.task_tree.setRootIsDecorated(False)
+        self.task_tree.setHeaderLabels(["#", "Task Title", "Due Date", "Priority"])
+        # Select entire rows, not individual cells
+        self.task_tree.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
+
+        # Allow selecting multiple rows (Shift/Ctrl click)
+        self.task_tree.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+
+        # THE MAGIC LINE: Forces the highlight to span the whole row evenly
+        self.task_tree.setAllColumnsShowFocus(True)
+
+        # Removes the ugly dotted outline that appears on the specific cell you click
+        self.task_tree.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.task_tree.setStyleSheet(
+            """
+            QTreeWidget {
+                background-color: rgba(30, 35, 40, 0.8);
+                color: white;
+                border-radius: 12px;
+                border: 1px solid rgba(255,255,255,0.08);
+                font-size: 13px;
+            }
+            QHeaderView::section {
+                background-color: #21262d;
+                color: #ffffff;
+                padding: 8px;
+                font-weight: bold;
+                border: none;
+                border-bottom: 1px solid #30363d;
+            }
+            QTreeWidget::item:selected { background-color: rgba(255,255,255,0.1); }
+        """
+        )
+
+        header = self.task_tree.header()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Fixed)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Fixed)
+        self.task_tree.setColumnWidth(2, 120)
+        self.task_tree.setColumnWidth(3, 90)
+
+        self.task_tree.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.task_tree.customContextMenuRequested.connect(self.show_context_menu)
+
+        layout.addWidget(self.task_tree)
+
+    def refresh(self) -> None:
+        """Refreshes the trash view by querying the database."""
+        from presentation.dashboard import ACTIVE_THEME_MAP
+
+        self.task_tree.clear()
+        query = self.search_bar.text()
+        tasks = self.task_manager.get_deleted_tasks(query)
+
+        for index, task in enumerate(tasks, start=1):
+            row_item = QTreeWidgetItem(
+                [
+                    str(index),  # Column 0: The Row Number
+                    task.title,  # Column 1: The Raw Title
+                    task.due_date if task.due_date else "--",  # Column 2: Date
+                    task.priority,  # Column 3: Priority
+                ]
+            )
+            row_item.setSizeHint(0, QSize(0, 32))
+            row_item.setData(0, Qt.ItemDataRole.UserRole, task.id)
+
+            bg_hex = (
+                task.color
+                if (hasattr(task, "color") and task.color in ACTIVE_THEME_MAP)
+                else "#333333"
+            )
+            fg_hex = ACTIVE_THEME_MAP.get(bg_hex, "#FFFFFF")
+
+            base = QColor(bg_hex)
+            pastel = QColor(base.red(), base.green(), base.blue(), 50)
+
+            for col in range(4):
+                row_item.setBackground(col, pastel)
+
+            row_item.setForeground(1, QColor(fg_hex))
+            row_item.setTextAlignment(
+                1, Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter
+            )
+
+            # Priority Badge Setup (similar to Kanban)
+            badge = QLabel(task.priority)
+            badge.setFixedSize(70, 20)
+            badge.setStyleSheet(
+                f"background-color: {bg_hex}; color: {fg_hex}; border-radius: 4px; padding: 2px 0px; font-size: 11px; font-weight: bold; border: none;"
+            )
+            badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+            badge_container = QWidget()
+            badge_layout = QHBoxLayout(badge_container)
+            badge_layout.setContentsMargins(30, 0, 5, 0)
+            badge_layout.addStretch()
+            badge_layout.addWidget(badge)
+
+            # Title Setup
+            title_container = QWidget()
+            title_layout = QHBoxLayout(title_container)
+            title_layout.setContentsMargins(10, 0, 0, 0)
+            title_lbl = QLabel(task.title)
+            title_lbl.setStyleSheet(
+                f"color: {fg_hex}; font-size: 13px; background: transparent;"
+            )
+            title_layout.addWidget(title_lbl)
+            title_layout.addStretch()
+
+            self.task_tree.setItemWidget(row_item, 1, title_container)
+            self.task_tree.setItemWidget(row_item, 3, badge_container)
+
+            self.task_tree.addTopLevelItem(row_item)
+
+    def show_context_menu(self, pos):
+        """Displays context menu for restoring or deleting tasks permanently."""
+        selected_items = self.task_tree.selectedItems()
+
+        # Guard clause: Do nothing if they clicked empty space
+        if not selected_items:
+            return
+
+        menu = QMenu(self)
+        restore_action = menu.addAction(f"Restore ({len(selected_items)}) Tasks")
+        perm_delete_action = menu.addAction(
+            f"Permanently Delete ({len(selected_items)}) Tasks"
+        )
+
+        action = menu.exec(self.task_tree.viewport().mapToGlobal(pos))
+
+        # Iterate and process
+        if action == restore_action:
+            for item in selected_items:
+                task_id = item.data(0, Qt.ItemDataRole.UserRole)
+                self.task_manager.restore_task(task_id)
+
+            self.refresh()
+            self.dashboard.load_tasks()
+
+        elif action == perm_delete_action:
+            confirm = QMessageBox.warning(
+                self,
+                "Permanent Delete",
+                f"This will permanently obliterate {len(selected_items)} task(s). Are you sure?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            )
+            if confirm == QMessageBox.StandardButton.Yes:
+                for item in selected_items:
+                    task_id = item.data(0, Qt.ItemDataRole.UserRole)
+                    self.task_manager.permanently_delete_task(task_id)
+                self.refresh()

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -325,7 +325,7 @@ def test_tc010_past_due_date_validation(app_window, qtbot):
 
             if (
                 top_widget.toast.isVisible()
-                and top_widget.toast.text() == "Due Date cannot be in the past!"
+                and top_widget.toast.text() == "Due Date/Time cannot be in the past!"
             ):
                 toast_activated = True
 
@@ -825,3 +825,47 @@ def test_tc023_analytics_refreshes_on_status_change(app_window, qtbot):
     stats_after = dashboard.task_manager.get_task_stats()
     assert stats_after["In Progress"] == 0
     assert stats_after["Completed"] == 1
+
+
+def test_tc025_datetime_parsing(app_window):
+    """TC-025: Verify backwards compatibility for legacy date vs new datetime string parsing"""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    # 1. Insert Legacy Task (Date Only)
+    dashboard.task_manager.add_task(
+        Task(
+            id=0,
+            title="Legacy Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="2020-01-01",  # Very old date
+            priority="Low",
+            color="#FFFFFF",
+            is_deleted=0,
+        )
+    )
+
+    # 2. Insert New Task (Full Datetime)
+    dashboard.task_manager.add_task(
+        Task(
+            id=0,
+            title="New Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="2020-01-01T14:30:00",  # Full datetime
+            priority="Low",
+            color="#FFFFFF",
+            is_deleted=0,
+        )
+    )
+
+    # This should safely parse both without throwing ValueError and accurately calculate overdue
+    stats = dashboard.task_manager.get_task_stats()
+
+    # Both tasks are from 2020, so they should both be counted as overdue
+    assert stats["overdue"] == 2
+    assert stats["total"] == 2

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -190,29 +190,28 @@ def test_tc006_tc007_trash_management(app_window, qtbot, monkeypatch):
     dashboard.set_mode("trash")
     assert dashboard.current_mode == "trash"
 
-    # Verify it exists in the Trash UI
-    trash_todo_group = dashboard.task_tree.topLevelItem(0)
-    assert trash_todo_group.childCount() == 2
-    assert "Trash Test Task" in trash_todo_group.child(1).text(0)
+    # Verify it exists in the Trash UI (flat list in TrashWidget)
+    assert dashboard.page_trash.task_tree.topLevelItemCount() == 1
+    trash_item = dashboard.page_trash.task_tree.topLevelItem(0)
+
+    # Title is injected via setItemWidget, so text(0) is empty. We can check via the underlying data
+    assert (
+        dashboard.task_manager.get_task_by_id(
+            trash_item.data(0, Qt.ItemDataRole.UserRole)
+        ).title
+        == "Trash Test Task"
+    )
 
     # Permanent Delete Workflow
     monkeypatch.setattr(
         QMessageBox, "warning", lambda *args: QMessageBox.StandardButton.Yes
     )
     dashboard.task_manager.permanently_delete_task(task_id)
-    dashboard.load_tasks()
-
-    # Permanent Delete Workflow
-    monkeypatch.setattr(
-        QMessageBox, "warning", lambda *args: QMessageBox.StandardButton.Yes
-    )
-    dashboard.task_manager.permanently_delete_task(task_id)
-    dashboard.load_tasks()  # <--- THIS VAPORIZES THE OLD POINTER!
+    dashboard.page_trash.refresh()  # <--- THIS VAPORIZES THE OLD POINTER!
 
     # Final Verification: Nulled from existence
     # We MUST re-fetch the pointer here!
-    trash_todo_group_cleared = dashboard.task_tree.topLevelItem(0)
-    assert trash_todo_group_cleared.childCount() == 1
+    assert dashboard.page_trash.task_tree.topLevelItemCount() == 0
 
     db_task = dashboard.task_manager.get_task_by_id(task_id)
     assert db_task is None

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -601,3 +601,228 @@ def test_tc017_banner_hides_when_no_urgent_tasks(app_window, qtbot):
 
     # Banner must auto-hide
     assert not dashboard.urgent_banner_btn.isVisible()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EP02: Task Productivity Analytics Dashboard
+# TC-018 → TC-023
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_tc018_analytics_widget_exists(app_window, qtbot):
+    """[EP02] TC-018: AnalyticsWidget instantiates cleanly and is wired into dashboard."""
+    from presentation.analytics_widget import AnalyticsWidget
+
+    dashboard = app_window.dashboard
+
+    # The widget must be attached to the dashboard and be a proper AnalyticsWidget
+    assert hasattr(dashboard, "analytics_widget")
+    assert isinstance(dashboard.analytics_widget, AnalyticsWidget)
+
+    # Confirm the inner scroll content area exists (structural integrity check)
+    assert hasattr(dashboard.analytics_widget, "_inner_layout")
+
+
+def test_tc019_analytics_empty_state(app_window, qtbot):
+    """[EP02] TC-019: With zero tasks the empty-state label is shown."""
+    dashboard = app_window.dashboard
+
+    # No tasks were added — ensure stats are all zero
+    stats = dashboard.task_manager.get_task_stats()
+    assert stats["total"] == 0
+    assert stats["Pending"] == 0
+    assert stats["Completed"] == 0
+    assert stats["overdue"] == 0
+
+    # Empty-state label must be present inside the donut container
+    donut_container = dashboard.analytics_widget._donut_container
+    labels = [
+        donut_container.layout().itemAt(i).widget()
+        for i in range(donut_container.layout().count())
+        if donut_container.layout().itemAt(i).widget() is not None
+    ]
+    empty_labels = [
+        w
+        for w in labels
+        if getattr(w, "objectName", lambda: "")() == "empty_state_label"
+    ]
+    assert len(empty_labels) == 1
+
+
+def test_tc020_analytics_counts_match_db(app_window, qtbot):
+    """[EP02] TC-020: Stats dict accurately reflects task records in the database."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="P1",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Medium",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="P2",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="High",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="C1",
+            description="",
+            status="Completed",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+
+    assert stats["total"] == 3
+    assert stats["Pending"] == 2
+    assert stats["Completed"] == 1
+    assert stats["In Progress"] == 0
+
+
+def test_tc021_analytics_priority_distribution(app_window, qtbot):
+    """[EP02] TC-021: Priority aggregation in stats matches tasks added per level."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Low Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Low Task 2",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Low",
+            is_deleted=0,
+        )
+    )
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="High Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date="",
+            priority="High",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+
+    assert stats["Low"] == 2
+    assert stats["High"] == 1
+    assert stats["Medium"] == 0
+    assert stats["Critical"] == 0
+
+
+def test_tc022_analytics_overdue_chip_fires(app_window, qtbot):
+    """[EP02] TC-022: A task with a past due date increments the overdue counter."""
+    from datetime import datetime
+
+    from PySide6.QtCore import QDate
+
+    dashboard = app_window.dashboard
+
+    past_date = QDate.currentDate().addDays(-3).toString("yyyy-MM-dd")
+    dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="Overdue Task",
+            description="",
+            status="Pending",
+            created_at=datetime.now(),
+            due_date=past_date,
+            priority="High",
+            is_deleted=0,
+        )
+    )
+
+    stats = dashboard.task_manager.get_task_stats()
+    assert stats["overdue"] == 1
+
+    # Refresh the widget and verify the overdue chip renders the warning text
+    dashboard.analytics_widget.refresh(dashboard.task_manager)
+    overdue_container = dashboard.analytics_widget._overdue_container
+    widgets = [
+        overdue_container.layout().itemAt(i).widget()
+        for i in range(overdue_container.layout().count())
+        if overdue_container.layout().itemAt(i).widget() is not None
+    ]
+    chip = next(
+        (
+            w
+            for w in widgets
+            if getattr(w, "objectName", lambda: "")() == "overdue_chip"
+        ),
+        None,
+    )
+    assert chip is not None
+    assert "overdue" in chip.text()
+
+
+def test_tc023_analytics_refreshes_on_status_change(app_window, qtbot):
+    """[EP02] TC-023: Completing a task updates the analytics stats correctly."""
+    from datetime import datetime
+
+    dashboard = app_window.dashboard
+
+    task_id = dashboard.task_manager.add_task(
+        Task(
+            id=None,
+            title="In Progress Task",
+            description="",
+            status="In Progress",
+            created_at=datetime.now(),
+            due_date="",
+            priority="Medium",
+            is_deleted=0,
+        )
+    )
+
+    stats_before = dashboard.task_manager.get_task_stats()
+    assert stats_before["In Progress"] == 1
+    assert stats_before["Completed"] == 0
+
+    # Simulate user completing the task (e.g. via right-click context menu)
+    dashboard.task_manager.update_task_status(task_id, "Completed")
+    dashboard.load_tasks()  # triggers analytics_widget.refresh() internally
+
+    stats_after = dashboard.task_manager.get_task_stats()
+    assert stats_after["In Progress"] == 0
+    assert stats_after["Completed"] == 1

--- a/tests/automation/test_features.py
+++ b/tests/automation/test_features.py
@@ -827,8 +827,8 @@ def test_tc023_analytics_refreshes_on_status_change(app_window, qtbot):
     assert stats_after["Completed"] == 1
 
 
-def test_tc025_datetime_parsing(app_window):
-    """TC-025: Verify backwards compatibility for legacy date vs new datetime string parsing"""
+def test_tc024_datetime_parsing(app_window):
+    """TC-024: Verify backwards compatibility for legacy date vs new datetime string parsing"""
     from datetime import datetime
 
     dashboard = app_window.dashboard


### PR DESCRIPTION
- Introduce format_due_countdown to produce short human-readable countdowns for task due dates (handles ISO datetimes and legacy YYYY-MM-DD by assuming end-of-day).
- Skip Completed or missing dates; show minutes/hours/days and overdue messages with distinct emojis.
- Apply tooltips to KanbanCard widgets and to all columns of dashboard rows so hovering anywhere shows the countdown.
- Also rename a test function identifier (tc025 → tc024) to keep tests consistent.
[feature/EP02-FT02-Sort-Task-List](https://github.com/jhoanna-delapaz/SE-Chimkens-Efficio/compare/feature/EP02-FT02-Sort-Task-List)
[feature/FT01-Task-Labeling-System](https://github.com/jhoanna-delapaz/SE-Chimkens-Efficio/compare/feature/FT01-Task-Labeling-System)